### PR TITLE
ci: port the CI half of the pipeline from GitLab to GitHub Actions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-project-licenses": {
+      "version": "2.7.1",
+      "commands": [
+        "dotnet-project-licenses"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/licenses/allowed-licenses.json
+++ b/.github/licenses/allowed-licenses.json
@@ -1,0 +1,10 @@
+[
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "MS-PL",
+  "0BSD",
+  "PostgreSQL"
+]

--- a/.github/licenses/license-packages-filter.json
+++ b/.github/licenses/license-packages-filter.json
@@ -1,0 +1,3 @@
+[
+  "xunit.abstractions"
+]

--- a/.github/scripts/verify-test-results.sh
+++ b/.github/scripts/verify-test-results.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Fail-safe guard against a FALSE GREEN test run, ported from .gitlab/ci/test.yml's
+# `.verify_results` anchor. GitHub Actions has no YAML anchors, so the guard lives here
+# and each test job calls it rather than triplicating the logic.
+#
+# Why this exists (GitLab issue #21 — legacy tracker number): `dotnet test` once ran ZERO
+# tests and still exited 0. The build stage's artifacts did not carry the NuGet global
+# packages cache (it lives outside the checkout), so Microsoft.NET.Test.Sdk.props's
+# Condition="Exists(...)" import silently failed to resolve, IsTestProject never got set,
+# and MSBuild's VSTest target was silently skipped. A pipeline that reports success while
+# executing nothing is worse than a red one.
+#
+# The GitHub Actions port removes the root cause — every test job runs its own `dotnet
+# restore` in its own container, so there is no cross-job artifact to be missing — but the
+# guard is kept regardless as a second line of defence against this class of bug recurring
+# for any other reason (NFR-REL-2: a meaningful check, not an unconditional pass).
+#
+# Also writes a run summary to $GITHUB_STEP_SUMMARY. GitLab rendered `reports: junit`
+# natively in the MR UI; Actions has no built-in equivalent, and this keeps the pass/fail
+# counts visible on the run page without taking a third-party action as a dependency.
+#
+# Usage: verify-test-results.sh [results-dir]   (default: TestResults)
+
+set -euo pipefail
+
+results_dir="${1:-TestResults}"
+
+if ! ls "$results_dir"/*.junit.xml >/dev/null 2>&1; then
+  echo "No test result files were produced in '$results_dir' - dotnet test ran silently and produced nothing (legacy issue #21). Failing rather than reporting a false green."
+  exit 1
+fi
+
+total_tests=$(grep -ohE 'tests="[0-9]+"' "$results_dir"/*.junit.xml | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+total_failures=$(grep -ohE 'failures="[0-9]+"' "$results_dir"/*.junit.xml | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+total_errors=$(grep -ohE 'errors="[0-9]+"' "$results_dir"/*.junit.xml | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+total_skipped=$(grep -ohE 'skipped="[0-9]+"' "$results_dir"/*.junit.xml | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+
+if [ "$total_tests" -eq 0 ]; then
+  echo "Test result files exist but report zero tests executed (legacy issue #21). Failing rather than reporting a false green."
+  exit 1
+fi
+
+echo "Verified: $total_tests test(s) actually executed ($total_failures failure(s), $total_errors error(s), $total_skipped skipped)."
+
+# Job summary - only when running under Actions, so the script stays runnable locally.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### ${GITHUB_JOB:-tests} results"
+    echo ""
+    echo "| Metric | Count |"
+    echo "|---|---|"
+    echo "| Executed | ${total_tests} |"
+    echo "| Failures | ${total_failures} |"
+    echo "| Errors | ${total_errors} |"
+    echo "| Skipped | ${total_skipped} |"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/.github/scripts/verify-test-results.sh
+++ b/.github/scripts/verify-test-results.sh
@@ -31,10 +31,33 @@ if ! ls "$results_dir"/*.junit.xml >/dev/null 2>&1; then
   exit 1
 fi
 
-total_tests=$(grep -ohE 'tests="[0-9]+"' "$results_dir"/*.junit.xml | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
-total_failures=$(grep -ohE 'failures="[0-9]+"' "$results_dir"/*.junit.xml | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
-total_errors=$(grep -ohE 'errors="[0-9]+"' "$results_dir"/*.junit.xml | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
-total_skipped=$(grep -ohE 'skipped="[0-9]+"' "$results_dir"/*.junit.xml | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+# Sum one numeric JUnit attribute across every result file.
+#
+# Done in a single awk rather than `grep | grep | awk` on purpose. Under
+# `set -euo pipefail` a grep that matches ZERO times exits 1, which fails the whole
+# pipeline and aborts this script — with no output at all, because the failure happens
+# inside a command substitution. A JUnit file that simply omits an attribute (some
+# loggers drop `errors="0"`) would therefore turn a perfectly good run into a red job
+# carrying no diagnostic: the exact misleading-CI-signal failure mode this guard exists
+# to prevent. awk has no such behaviour — an attribute that never matches leaves the
+# running total at 0, which is the intended reading, and lets a genuinely empty run flow
+# into the explicit total_tests check below instead of dying before it.
+sum_attr() {
+  awk -v attr="$1" '
+    {
+      while (match($0, attr "=\"[0-9]+\"")) {
+        s += substr($0, RSTART + length(attr) + 2, RLENGTH - length(attr) - 3)
+        $0 = substr($0, RSTART + RLENGTH)
+      }
+    }
+    END { print s + 0 }
+  ' "$results_dir"/*.junit.xml
+}
+
+total_tests=$(sum_attr tests)
+total_failures=$(sum_attr failures)
+total_errors=$(sum_attr errors)
+total_skipped=$(sum_attr skipped)
 
 if [ "$total_tests" -eq 0 ]; then
   echo "Test result files exist but report zero tests executed (legacy issue #21). Failing rather than reporting a false green."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,283 @@
+# -----------------------------------------------------------------------------
+# CI — lint, build, test, evals. Ported from the retired GitLab pipeline
+# (.gitlab/ci/{lint,build,test,evals}.yml); see documentation/CI-SETUP.md.
+#
+# This is the CI half only. The deploy/verify half (Railway deploys, post-deploy
+# smoke tests, integration tests) is a separate follow-up: it needs ~18 repository
+# secrets that do not exist yet, and it touches live infrastructure. Everything
+# here runs with NO secrets at all.
+#
+# Three things changed shape in the port rather than being copied across:
+#
+#  1. No merge-with-target preamble. The GitLab pipeline ran a `git fetch` +
+#     `git merge` of the MR target branch in a global before_script so that a
+#     pipeline tested "your changes + current target", not a stale snapshot.
+#     Actions gives this for free: a `pull_request` run checks out the MERGE
+#     COMMIT (refs/pull/N/merge), and GitHub blocks the PR outright when that
+#     merge is conflicted. The preamble - and the GIT_DEPTH tuning that existed
+#     only to make its merge-base lookup work - is gone.
+#
+#  2. No cross-job build artifact. GitLab passed **/bin/ + **/obj/ from `build`
+#     to the test jobs so they could use --no-build. That artifact could not
+#     carry the NuGet global packages cache (it lives outside the checkout),
+#     which is the root cause of the false-green in legacy issue #21 and forced a
+#     `dotnet restore` before every --no-build test anyway. It also dragged in
+#     ~100MB Playwright driver copies that had to be excluded by hand to stay
+#     under the artifact size limit. Uploading tens of thousands of small files
+#     through Actions' artifact API is slow and loses the executable bit, so each
+#     job restores and builds in its own container instead, with the NuGet cache
+#     shared via actions/cache. That deletes the whole bug class.
+#
+#  3. No native JUnit report. GitLab rendered `reports: junit` inline in the MR.
+#     Actions has no equivalent, so .github/scripts/verify-test-results.sh writes
+#     the counts to the job summary and the raw XML is uploaded as an artifact.
+#     Deliberately not a third-party reporter action - that would be a supply-chain
+#     dependency on every CI run for cosmetics.
+# -----------------------------------------------------------------------------
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# = GitLab's `interruptible: true`. Superseded runs on the same ref are cancelled;
+# main is excluded so a merge always produces a complete, attributable run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+env:
+  SOLUTION: MarqSpec.AgentForge.slnx
+  BUILD_CONFIG: Release
+  UNIT_TEST_PATTERN: "*UnitTests.csproj"
+  DOTNET_NOLOGO: "true"
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # LINT — style/format gate + third-party license gate
+  # (ENGINEERING_STANDARDS.md §10). Runs alongside build so a style or license
+  # violation surfaces without waiting on the test matrix.
+  # ---------------------------------------------------------------------------
+  format:
+    name: format
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/dotnet/sdk:10.0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: nuget-${{ runner.os }}-
+      - name: dotnet format --verify-no-changes
+        run: dotnet format "$SOLUTION" --verify-no-changes
+
+  # Fails the run if any dependency (direct or transitive) resolves to a license outside
+  # .github/licenses/allowed-licenses.json - catches a restrictive-license bump before it
+  # merges (ENGINEERING_STANDARDS.md §2, the FluentAssertions v8 commercial-license note).
+  #
+  # --use-project-assets-json reads the resolved project.assets.json. Central Package
+  # Management leaves PackageReference elements without a Version attribute, which the tool
+  # cannot resolve from the csproj alone, so this restores first to populate it.
+  #
+  # license-packages-filter.json narrowly exempts xunit.abstractions: it is genuinely
+  # Apache-2.0 (same as the rest of the xunit project) but its NuGet package metadata has no
+  # machine-readable license tag, only a LicenseUrl - a known metadata gap, not a license
+  # risk. Extend that file only for the same kind of verified false positive.
+  license-scan:
+    name: license-scan
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/dotnet/sdk:10.0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: nuget-${{ runner.os }}-
+      - name: Restore (populates project.assets.json for the scanner)
+        run: dotnet restore "$SOLUTION"
+      - name: Scan licenses
+        env:
+          DOTNET_ROLL_FORWARD: LatestMajor
+        run: |
+          dotnet tool install --global dotnet-project-licenses
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          dotnet-project-licenses -i . --use-project-assets-json -t \
+            --allowed-license-types .github/licenses/allowed-licenses.json \
+            --packages-filter .github/licenses/license-packages-filter.json \
+            --json --outfile licenses-report.json -l Warning
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: licenses-report
+          path: licenses-report.json
+          retention-days: 7
+
+  # Validates reverse-proxy/nginx.conf.template's syntax without needing real upstream hosts
+  # or a deployed environment. `nginx -t` only checks the RENDERED config, so the template's
+  # ${VAR} placeholders are substituted with placeholders first (envsubst, the same mechanism
+  # nginx's docker-entrypoint uses at container start) - this never needs the real Railway
+  # upstream hostnames, and needs no secrets.
+  #
+  # Runs nginx via `docker run` rather than as a job `container:`. nginx:1.27-alpine is
+  # musl-based, and Actions injects its own glibc-built Node into container jobs to run
+  # JS actions like actions/checkout - which fails on musl. Checking out on the host and
+  # shelling into the image sidesteps that entirely.
+  nginx-config-lint:
+    name: nginx-config-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Render template and validate
+        run: |
+          docker run --rm -v "$PWD:/work" -w /work \
+            -e PORT=8080 \
+            -e OPENEMR_UPSTREAM=openemr.railway.internal:80 \
+            -e SIDECAR_UPSTREAM=agent-forge-api.railway.internal:8080 \
+            -e DNS_RESOLVER=127.0.0.11 \
+            nginx:1.27-alpine sh -c '
+              envsubst "\$PORT \$OPENEMR_UPSTREAM \$SIDECAR_UPSTREAM \$DNS_RESOLVER" \
+                < reverse-proxy/nginx.conf.template > /etc/nginx/conf.d/default.conf
+              nginx -t
+            '
+
+  # ---------------------------------------------------------------------------
+  # BUILD — compile gate. The test jobs below rebuild in their own containers
+  # (see header note 2), so this does not hand anything downstream; it exists so
+  # a compile error surfaces as ONE red job instead of three, and so the NuGet
+  # cache is warm by the time the test jobs start.
+  # ---------------------------------------------------------------------------
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/dotnet/sdk:10.0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: nuget-${{ runner.os }}-
+      - name: Restore
+        run: dotnet restore "$SOLUTION"
+      - name: Build
+        run: dotnet build "$SOLUTION" --no-restore -c "$BUILD_CONFIG"
+
+  # ---------------------------------------------------------------------------
+  # TEST — unit tests (fully mocked) and the deterministic eval rubrics.
+  #
+  # The integration suite is NOT here: it runs post-deploy against the real
+  # OpenEMR and is part of the deploy/verify half still to be ported.
+  #
+  # Results handling: every project writes into ONE shared results directory via
+  # --results-directory, and each logger uses LogFileName (relative to it) rather
+  # than LogFilePath, so the artifact glob cannot miss nested per-project
+  # TestResults locations. {assembly} keeps filenames unique across projects.
+  # ---------------------------------------------------------------------------
+  unit-tests:
+    name: unit-tests
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/dotnet/sdk:10.0
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: nuget-${{ runner.os }}-
+      - name: Run unit tests
+        run: |
+          set -e
+          projects=$(find . -type f -name "$UNIT_TEST_PATTERN" -not -path "*/bin/*" -not -path "*/obj/*")
+          if [ -z "$projects" ]; then
+            echo "No unit test projects matched '$UNIT_TEST_PATTERN'. Fix UNIT_TEST_PATTERN in .github/workflows/ci.yml."
+            exit 1
+          fi
+          for proj in $projects; do
+            echo "dotnet test $proj"
+            dotnet test "$proj" -c "$BUILD_CONFIG" \
+              --results-directory "$GITHUB_WORKSPACE/TestResults" \
+              --logger "junit;LogFileName={assembly}.junit.xml" \
+              --logger "trx;LogFileName={assembly}.trx"
+          done
+      - name: Verify tests actually ran
+        if: always()
+        run: bash .github/scripts/verify-test-results.sh TestResults
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-unit
+          path: TestResults/
+          retention-days: 7
+
+  # The DETERMINISTIC eval rubrics (schema_valid / citation_present / no_phi_in_logs) run as
+  # xUnit theory tests - one result per golden case - so an extraction/schema regression shows
+  # up as an ordinary red test. This is the hermetic half of the eval split: it never calls an
+  # LLM judge. The baseline/regression policy and the judge-bound rubrics stay in the `evals`
+  # job below. Single known project, so its path is referenced directly rather than globbed.
+  eval-tests:
+    name: eval-tests
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/dotnet/sdk:10.0
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: nuget-${{ runner.os }}-
+      - name: Run eval tests
+        run: |
+          dotnet test "tests/MarqSpec.AgentForge.EvalTests/MarqSpec.AgentForge.EvalTests.csproj" \
+            -c "$BUILD_CONFIG" \
+            --results-directory "$GITHUB_WORKSPACE/TestResults" \
+            --logger "junit;LogFileName={assembly}.junit.xml" \
+            --logger "trx;LogFileName={assembly}.trx"
+      - name: Verify tests actually ran
+        if: always()
+        run: bash .github/scripts/verify-test-results.sh TestResults
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-eval
+          path: TestResults/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # EVALS — the Week 2 eval-driven HARD GATE (Core Req 6). Runs the golden-set
+  # eval (deterministic, no database, no live API) and FAILS the run when any
+  # rubric category drops below its threshold or regresses beyond the tolerance
+  # in evals/baseline.json. A red `evals` job blocks the PR - this is the
+  # PR-blocking "git hook equivalent". See evals/README.md and
+  # W2_ARCHITECTURE.md §8.
+  # ---------------------------------------------------------------------------
+  evals:
+    name: evals
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/dotnet/sdk:10.0
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: nuget-${{ runner.os }}-
+      - name: Run golden-set eval gate
+        run: dotnet run --project "tests/MarqSpec.AgentForge.Evals" -c "$BUILD_CONFIG" -- evals
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: eval-results
+          path: evals/results.json
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,13 @@ jobs:
   # Apache-2.0 (same as the rest of the xunit project) but its NuGet package metadata has no
   # machine-readable license tag, only a LicenseUrl - a known metadata gap, not a license
   # risk. Extend that file only for the same kind of verified false positive.
+  #
+  # The scanner is pinned via the tool manifest (.config/dotnet-tools.json), NOT installed
+  # latest-wins. An unpinned `dotnet tool install` makes this gate non-deterministic: a new
+  # upstream release can change detection behaviour or break the job with no change in this
+  # repo, and it is an unpinned dependency fetched on every run. 3.0.0-alpha is already
+  # published, so "latest stable" is one release away from a major bump. The manifest keeps
+  # CI and local runs on the same version and makes the pin reviewable in source.
   license-scan:
     name: license-scan
     runs-on: ubuntu-latest
@@ -100,17 +107,17 @@ jobs:
       - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj', '.config/dotnet-tools.json') }}
           restore-keys: nuget-${{ runner.os }}-
       - name: Restore (populates project.assets.json for the scanner)
         run: dotnet restore "$SOLUTION"
+      - name: Restore pinned tools
+        run: dotnet tool restore
       - name: Scan licenses
         env:
           DOTNET_ROLL_FORWARD: LatestMajor
         run: |
-          dotnet tool install --global dotnet-project-licenses
-          export PATH="$PATH:$HOME/.dotnet/tools"
-          dotnet-project-licenses -i . --use-project-assets-json -t \
+          dotnet tool run dotnet-project-licenses -- -i . --use-project-assets-json -t \
             --allowed-license-types .github/licenses/allowed-licenses.json \
             --packages-filter .github/licenses/license-packages-filter.json \
             --json --outfile licenses-report.json -l Warning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/dotnet/sdk:10.0
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v7
+      - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
@@ -96,8 +96,8 @@ jobs:
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/dotnet/sdk:10.0
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v7
+      - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
@@ -114,7 +114,7 @@ jobs:
             --allowed-license-types .github/licenses/allowed-licenses.json \
             --packages-filter .github/licenses/license-packages-filter.json \
             --json --outfile licenses-report.json -l Warning
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: licenses-report
@@ -135,7 +135,7 @@ jobs:
     name: nginx-config-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Render template and validate
         run: |
           docker run --rm -v "$PWD:/work" -w /work \
@@ -160,8 +160,8 @@ jobs:
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/dotnet/sdk:10.0
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v7
+      - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
@@ -188,8 +188,8 @@ jobs:
     container: mcr.microsoft.com/dotnet/sdk:10.0
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v7
+      - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
@@ -212,7 +212,7 @@ jobs:
       - name: Verify tests actually ran
         if: always()
         run: bash .github/scripts/verify-test-results.sh TestResults
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results-unit
@@ -230,8 +230,8 @@ jobs:
     container: mcr.microsoft.com/dotnet/sdk:10.0
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v7
+      - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
@@ -246,7 +246,7 @@ jobs:
       - name: Verify tests actually ran
         if: always()
         run: bash .github/scripts/verify-test-results.sh TestResults
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results-eval
@@ -267,15 +267,15 @@ jobs:
     container: mcr.microsoft.com/dotnet/sdk:10.0
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v7
+      - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
           restore-keys: nuget-${{ runner.os }}-
       - name: Run golden-set eval gate
         run: dotnet run --project "tests/MarqSpec.AgentForge.Evals" -c "$BUILD_CONFIG" -- evals
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: eval-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,28 @@
 
 name: CI
 
+# `develop` is listed alongside `main` because it is the sole integration branch and is
+# protected: without a push trigger the commit that actually lands on `develop` is never
+# verified on its own. A PR run tests the merge preview, but this repo allows SQUASH merges,
+# and a squashed commit is a new object that never existed when the PR ran - "require branches
+# to be up to date" does not close that gap. It also means a direct push to a protected
+# `develop` could never acquire the required checks at all.
+#
+# Note this is an explicit branch LIST, not a catch-all. The retired GitLab pipeline
+# deliberately had no bare `$CI_COMMIT_BRANCH` rule (legacy issue #40): every branch here gets
+# a PR opened right after its first push, so a catch-all ran the same commits twice - once on
+# the raw branch ref, once on the MR pipeline. Naming only the integration branches keeps that
+# fixed: feature branches still run via `pull_request` alone. Do not widen this to all branches.
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, develop]
 
-# = GitLab's `interruptible: true`. Superseded runs on the same ref are cancelled;
-# main is excluded so a merge always produces a complete, attributable run.
+# = GitLab's `interruptible: true`. Superseded runs on the same ref are cancelled; the
+# integration branches are excluded so every merge produces one complete, attributable run.
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,14 @@ these AGENTS files summarize and point to it.
   a workaround, a surprising invariant) — never restate *what* the code does. XML doc comments on public
   methods describe behavior/contract only.
 - **Reference comments are allowed, but must be prefixed `reference:`.** A comment may point to a
-  `documentation/` file/section or a GitLab issue/MR/epic (e.g., `// reference: documentation/ARCHITECTURE.md
-  §9` or `// reference: gitlab#62`) when it's the fastest way to point a future agent at fuller context. The
+  `documentation/` file/section or a GitHub issue/PR (e.g., `// reference: documentation/ARCHITECTURE.md
+  §9` or `// reference: gh#62`) when it's the fastest way to point a future agent at fuller context. The
   `reference:` prefix keeps these grep-able and visually distinct from an ordinary comment — it never
   substitutes for the *why*, which must still be stated inline, not left implicit behind the link.
+  **Existing `gitlab#N` / `GitLab issue #N` citations address the RETIRED GitLab tracker and do not map to
+  GitHub** — issue numbers did not survive the migration (old #109 was the click-to-source `Binary.read`
+  scope; GitHub #109 is an unrelated QA-login issue). Treat them as historical context only, never as links,
+  and use `gh#N` for anything new. See `documentation/INDEX.md` §5.
 - **Commits:** Conventional Commits; add `Assisted-by:` trailer when authored by an AI agent.
 - **No orphaned MRs.** Every MR references a tracking issue (`Closes #N` / `Related to #N`) that states the
   problem or requirement being addressed, opened *before* the MR. If no issue exists yet for the work, open

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,11 +88,16 @@
 
     <!--
       Security pin: Microsoft.EntityFrameworkCore.Design's MSBuild/Roslyn tooling pulls
-      System.Security.Cryptography.Xml 9.0.0, which has a high-severity CVE (NU1903). Pin up to the patched
-      10.0.9 (matches our other MS package cadence). The Design package is design-time only (PrivateAssets),
+      System.Security.Cryptography.Xml 9.0.0, which has a high-severity CVE (NU1903). Pin up to a patched
+      release (matches our other MS package cadence). The Design package is design-time only (PrivateAssets),
       so this never ships at runtime - it exists solely to keep the audit gate green.
+
+      This pin needs re-bumping whenever the pinned version itself picks up an advisory: 10.0.9 was the
+      patched target until GHSA-23rf-6693-g89p / -8q5v-6pqq-x66h / -cvvh-rhrc-wg4q / -g8r8-53c2-pm3f landed
+      against it, which turned every `dotnet build` red under warnings-as-errors. 10.0.10 clears all four.
+      Treat a NU1903 on this package as "bump the pin", not "suppress the audit".
     -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 
     <!-- Test infrastructure (both test projects) -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ no browser caller — is blocked at the proxy:
 | `MarqSpec.AgentForge.slnx` | Solution file (repo root) |
 | `src/` | Production projects (`MarqSpec.AgentForge.*`) — see layout in `ENGINEERING_STANDARDS.md` §9 |
 | `tests/` | Four test projects: `…UnitTests` (mocked), `…IntegrationTests` (real deps in QA), `…EvalTests` (deterministic rubric checks), and `…Evals` (golden-set eval runner; cases in top-level `evals/`) |
-| `reverse-proxy/` | Nginx front-door container/config for the same-origin reverse-proxy front door (issue #62, closed; agent-forge#22) — deployed on staging as `agent-forge-reverse-proxy` (the live-demo front door above); CI lives inline in `.gitlab/ci/`; see its own README |
+| `reverse-proxy/` | Nginx front-door container/config for the same-origin reverse-proxy front door (issue #62, closed; agent-forge#22) — deployed on staging as `agent-forge-reverse-proxy` (the live-demo front door above); its config lint runs in `.github/workflows/ci.yml`; see its own README |
 | `AGENTS.md` · `src/AGENTS.md` · `tests/AGENTS.md` | Instructions for AI coding agents (root + per-role) |
 | `CLAUDE.md` (each level) | One-line shims so Claude Code honors the same `AGENTS.md` rules |
 

--- a/documentation/CI-SETUP.md
+++ b/documentation/CI-SETUP.md
@@ -1,120 +1,139 @@
 # Agent Forge Copilot — CI/CD Setup Notes
 
-The pipeline entry point is `.gitlab-ci.yml` at the repo **root** (GitLab
-auto-discovers it — no project setting required), and the per-stage jobs live
-under `.gitlab/`:
+CI runs on **GitHub Actions**. The pipeline entry point is
+`.github/workflows/ci.yml`, which GitHub auto-discovers — no repository setting
+required.
 
 ```
-.gitlab-ci.yml            <- pipeline root: workflow, stages, defaults, includes
-.gitlab/
-└── ci/
-    ├── lint.yml          <- lint stage: dotnet format + third-party license scan
-    ├── build.yml         <- build stage
-    ├── test.yml          <- unit test stage (integration suite defined here but runs post-deploy, #70)
-    ├── evals.yml         <- eval gate (runs in the test stage)
-    ├── deploy.yml        <- deploy stage (auto on main)
-    └── verify.yml        <- verify stage: post-deploy /health + /ready smoke test + health-gated integration suite
+.github/
+├── workflows/
+│   └── ci.yml                      <- lint + build + test + evals (this document)
+├── scripts/
+│   └── verify-test-results.sh      <- shared false-green guard (see §5)
+└── licenses/
+    ├── allowed-licenses.json       <- license allowlist for the license gate
+    └── license-packages-filter.json
 ```
 
-The root file `include:`s the six fragments. Everything about *where* and
-*how* the pipeline runs is defined in code — the only remaining items below are
-GitLab **policy** settings (who can merge when), which have no in-file
-equivalent.
+> **Migration status.** This repo ran on GitLab CI until the move to GitHub. The
+> **CI half** (lint, build, test, evals) is ported and live. The **CD half** —
+> Railway deploys, the post-deploy `/health` + `/ready` smoke tests, and the
+> health-gated integration suite — is **not yet ported**; it needs repository
+> secrets that do not exist yet and it touches live infrastructure. The retired
+> `.gitlab-ci.yml` and `.gitlab/ci/` are kept **temporarily and inertly** as the
+> reference for that port (nothing on GitHub reads them) and should be deleted
+> once CD lands. Until then, **deploys are manual**.
 
-## 1. Commit the files
+## 1. What runs, and when
 
-Add `.gitlab-ci.yml` and the `.gitlab/ci/` folder to the repo. Before the first
-run, check the three variables at the top of `.gitlab-ci.yml`:
-
-| Variable | Default | What to set it to |
+| Job | Stage | Gate |
 |---|---|---|
-| `SOLUTION` | auto-detect | Your `.sln` path if the root has more than one solution/project |
-| `UNIT_TEST_PATTERN` | `*UnitTests.csproj` | Whatever your unit test projects are actually named |
-| `INTEGRATION_TEST_PATTERN` | `*IntegrationTests.csproj` | Same for integration test projects |
+| `format` | lint | `dotnet format --verify-no-changes` |
+| `license-scan` | lint | fails on a dependency outside `allowed-licenses.json` |
+| `nginx-config-lint` | lint | renders `nginx.conf.template` and runs `nginx -t` |
+| `build` | build | compile under warnings-as-errors |
+| `unit-tests` | test | fully mocked suite |
+| `eval-tests` | test | deterministic eval rubrics as xUnit theories |
+| `evals` | test | golden-set **hard gate** (Core Req 6) |
 
-Both test jobs **fail loudly if zero projects match**, so a wrong pattern can't
-silently produce a green pipeline.
+Triggers are `pull_request` (any branch) and `push` to `main`, matching the old
+GitLab `workflow.rules`. Concurrency cancels superseded runs on the same ref
+(the old `interruptible: true`), except on `main`, so every merge produces one
+complete attributable run.
 
-Also adjust `ConnectionStrings__DefaultConnection` in `.gitlab/ci/test.yml`
-(the `integration-tests` job) to match the config key your code reads. In .NET,
-a double underscore maps to `:`, so `ConnectionStrings__DefaultConnection`
-⇒ `ConnectionStrings:DefaultConnection` in `appsettings.json`.
+The three lint jobs and `build` run in parallel; the three test jobs depend on
+`build` so a compile error surfaces as one red job rather than four.
 
-> Tip: **CI/CD → Editor** validates and visualizes the merged pipeline
-> (root + includes) — a fast way to confirm the `include:` paths resolve.
+Check the variables in the workflow's `env:` block if project names change —
+`SOLUTION`, `BUILD_CONFIG`, `UNIT_TEST_PATTERN`. `unit-tests` **fails loudly if
+zero projects match** its pattern, so a wrong pattern cannot silently produce a
+green run.
 
-## 2. Block merging on red pipelines (requirement: "user must fix")
+## 2. Block merging on red runs
 
-**Settings → Merge requests → Merge checks:**
+GitHub's equivalent of GitLab's "Pipelines must succeed" is **branch protection
+with required status checks**. Without it a failing run is only advisory and the
+PR stays mergeable.
 
-- ✅ **Pipelines must succeed**
-- ✅ **Skipped pipelines are considered failed** (closes a loophole)
+On **Settings → Branches → Branch protection rules** for `develop` and `main`:
 
-Without this, a failing pipeline is only advisory — GitLab will still let the
-MR merge. (This is a project policy setting; there is no in-repo equivalent.)
+- ✅ **Require status checks to pass before merging**, selecting: `format`,
+  `license-scan`, `nginx-config-lint`, `build`, `unit-tests`, `eval-tests`,
+  `evals`
+- ✅ **Require branches to be up to date before merging** (see §3)
 
-## 3. Re-test when other branches merge into main
+Status checks only become selectable **after the workflow has run at least
+once** on the repo — so merge this workflow first, then configure protection.
 
-Two layers cover this:
+## 3. Freshness against the target branch
 
-1. **In the YAML (works on any tier):** every MR job starts by merging the
-   latest `main` into the MR head (the `before_script` in `.gitlab-ci.yml`). So
-   whenever the pipeline runs, it tests *your changes + current main*, not a
-   stale snapshot. A conflict with main fails the pipeline immediately with a
-   clear message.
-2. **Auto re-run when main moves:** GitLab only *automatically* re-runs MR
-   pipelines on target-branch changes with **merged results pipelines / merge
-   trains** (Premium features). Check **Settings → Merge requests → Merge
-   options** — if you see **"Enable merged results pipelines"**, turn it on
-   (and optionally merge trains). On the Free tier, the fallback is the layer-1
-   merge plus hitting **Run pipeline** on the MR (or push/rebase) after main
-   moves. "Pipelines must succeed" still guarantees nothing merges without a
-   green run.
+The old GitLab pipeline ran a `git fetch` + `git merge` of the target branch in a
+global `before_script` so a run tested "your changes + current target" rather
+than a stale snapshot.
 
-**Settings → CI/CD → General pipelines:** enable
-**Auto-cancel redundant pipelines** so rapid pushes don't queue up stale runs.
+**Actions gives this for free.** A `pull_request` run checks out the *merge
+commit* (`refs/pull/N/merge`) — already your branch merged with the current
+target — and GitHub blocks the PR outright when that merge conflicts. The
+preamble is gone, along with the `GIT_DEPTH` tuning that existed only to make
+its merge-base lookup work.
 
-## 4. Main must pass tests before deploy
+What Actions does *not* do automatically is re-run a PR when the target branch
+moves. **"Require branches to be up to date before merging"** (§2) closes that:
+it forces an update-and-re-run before the merge button unlocks. This is the free
+equivalent of GitLab's Premium-only merged-results pipelines.
 
-Enforced by pipeline stage ordering: `lint → build → test → deploy → verify`. A
-failed `lint`, `build`, `unit-tests`, or `evals` job stops the pipeline before
-`deploy` ever runs. **`integration-tests` deliberately does *not* gate `deploy`**
-(#70): it drives a live browser login against the external QA OpenEMR, so it runs
-**post-deploy** in the `verify` stage, health-gated (it waits for OpenEMR to be
-serving and skips with a distinct signal otherwise) — a transient OpenEMR outage
-can't veto a sidecar deploy that its own build + unit tests already passed. The
-rest of `verify` curls `/health` and `/ready` against the deployed instance.
-`deploy` itself runs **automatically** on `main`
-(`.gitlab/ci/deploy.yml`, `rules: if $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH` —
-no manual gate) and ships via `railway up --service agent-forge-api-staging --ci`; see
-`RAILWAY.md` for the deployed target and rollback procedure.
+## 4. Test reporting
 
-## 5. Failed-test widget in MRs — done
+GitLab rendered `reports: junit` inline in the MR. Actions has no built-in
+equivalent, so:
 
-`JunitXml.TestLogger` is added to both test projects (`Directory.Packages.props`),
-`.gitlab/ci/test.yml` logs `--logger "junit;LogFileName={assembly}.junit.xml"`,
-and the `reports: junit:` block in the shared test template is live. Failed
-tests surface inline in the MR, not just in job logs.
+- `verify-test-results.sh` writes pass/fail/skip counts to the **job summary**,
+  visible on the run page
+- raw JUnit + TRX XML uploads as a **workflow artifact** (7-day retention)
 
-## What else fits in `.gitlab/`
+Deliberately **not** a third-party reporter action — that would add a
+supply-chain dependency on every CI run for what is essentially cosmetics.
 
-Since you're consolidating, GitLab natively recognizes these subfolders too, if
-you ever want them:
+## 5. The false-green guard
 
-- `.gitlab/merge_request_templates/*.md` — MR description templates
-- `.gitlab/issue_templates/*.md` — issue templates
-- `.gitlab/agents/` — GitLab Agent for Kubernetes config
+`.github/scripts/verify-test-results.sh` runs after every test job and **fails
+the job** if either (a) no `*.junit.xml` was produced, or (b) the combined
+`tests="N"` count is zero.
 
-## How the flow looks day-to-day
+This exists because `dotnet test` once ran **zero tests and still exited 0**
+(legacy tracker issue #21): the GitLab build stage's artifacts could not carry
+the NuGet global packages cache, so `Microsoft.NET.Test.Sdk.props`'s
+`Condition="Exists(...)"` import silently failed, `IsTestProject` never got set,
+and MSBuild's VSTest target was silently skipped.
 
-1. Dev opens an MR → pipeline runs lint → build → unit-tests → evals. Red
-   pipeline = merge button locked until they push a fix. (Integration tests
-   run post-deploy on `main`, not on MRs — see §4 / #70.)
-2. Dev pushes more commits → pipeline re-runs automatically (old run auto-cancels).
-3. Someone else merges to main → this MR's next run tests against the new main
-   (auto-triggered on Premium; manual "Run pipeline"/rebase on Free).
-4. MR merges → `main` pipeline runs the full suite again on the merged result.
-5. MR merges to main and the pipeline is green → `deploy` runs **automatically**
-   (no manual gate), then `verify` smoke-tests `/health` + `/ready` against the
-   deployed instance and runs the health-gated integration suite (#70). Main is
-   red on lint/build/unit/evals → the pipeline stops before `deploy` ever runs.
+The Actions port removes that root cause — every job restores in its own
+container, so there is no cross-job artifact to be missing — but the guard stays
+as a second line of defence (NFR-REL-2: a meaningful check, not an unconditional
+pass). It is unit-tested against three cases: no results, zero-test results, and
+results with real failures.
+
+## 6. Why there is no shared build artifact
+
+GitLab passed `**/bin/` + `**/obj/` from `build` to the test jobs so they could
+use `--no-build`. That artifact was the direct cause of the issue-#21 false green
+(above), forced a `dotnet restore` before every `--no-build` test anyway, and
+dragged in ~100MB Playwright driver copies that had to be hand-excluded to stay
+under the artifact size limit.
+
+Actions instead shares the **NuGet package cache** via `actions/cache`, keyed on
+`Directory.Packages.props` + all `*.csproj`, and each job restores and builds in
+its own container. Uploading tens of thousands of small files through the
+artifact API is slow and loses the executable bit; caching the packages is both
+faster and removes the whole bug class.
+
+## 7. Day-to-day flow
+
+1. Dev opens a PR → `format`, `license-scan`, `nginx-config-lint`, `build` run in
+   parallel, then `unit-tests`, `eval-tests`, `evals`. Red run = merge button
+   locked (given §2).
+2. Dev pushes more commits → the run re-triggers and the superseded one cancels.
+3. Someone merges to the target branch → "require branches to be up to date"
+   forces an update, which re-runs against the new target.
+4. PR merges → the `main` push run executes the same suite on the merged result.
+5. **Deploy is manual** until the CD half is ported — see the migration note at
+   the top and `RAILWAY.md` for the deploy and rollback procedure.

--- a/documentation/CI-SETUP.md
+++ b/documentation/CI-SETUP.md
@@ -36,10 +36,24 @@ required.
 | `eval-tests` | test | deterministic eval rubrics as xUnit theories |
 | `evals` | test | golden-set **hard gate** (Core Req 6) |
 
-Triggers are `pull_request` (any branch) and `push` to `main`, matching the old
-GitLab `workflow.rules`. Concurrency cancels superseded runs on the same ref
-(the old `interruptible: true`), except on `main`, so every merge produces one
+Triggers are `pull_request` (any branch) and `push` to **`main` and `develop`**.
+Concurrency cancels superseded runs on the same ref (the old `interruptible:
+true`), except on those two integration branches, so every merge produces one
 complete attributable run.
+
+Both integration branches are in the push list because each is protected (§2) and
+the commit that actually lands there needs verifying on its own. A PR run tests
+the *merge preview*; with squash merges enabled, the commit that lands is a new
+object that never existed when the PR ran, so "require branches to be up to date"
+does not cover it. It also means a direct push to a protected branch can acquire
+the required checks instead of being permanently unmergeable.
+
+> This is an explicit list, **not** a catch-all. The GitLab pipeline deliberately
+> had no bare `$CI_COMMIT_BRANCH` rule (legacy issue #40): every branch here gets a
+> PR right after its first push, so a catch-all tested the same commits twice —
+> once on the raw branch ref, once on the MR pipeline. Naming only the integration
+> branches keeps that fixed; feature branches run via `pull_request` alone. Don't
+> widen it.
 
 The three lint jobs and `build` run in parallel; the three test jobs depend on
 `build` so a compile error surfaces as one red job rather than four.


### PR DESCRIPTION
Restores CI on this repo. GitLab is retired and nothing replaced it, so **every PR here has
been merging unverified**.

> **#362 has merged**, so this now targets `develop` directly and the diff is CI-only — the
> rename it depended on (`MarqSpec.AgentForge.slnx`) is already on `develop`.

## Scope: CI only, deliberately

| | Jobs | Secrets | State |
|---|---|---|---|
| **CI** — lint, build, test, evals | 7 | none | this PR |
| **CD** — deploy, verify, smoke, integration | 8 | ~18 | follow-up |

Everything here runs with **no secrets**, so it goes green on merge. The CD half touches live
Railway infrastructure and needs secrets that don't exist on this repo yet.

## Included: a one-line security fix that unblocks all of this

`develop` is currently **red on its own**. The existing `System.Security.Cryptography.Xml` pin
escaped a CVE in 9.0.0 by pinning to 10.0.9 — and four advisories have since landed against
10.0.9 itself, which `TreatWarningsAsErrors` turns into a build failure.

`10.0.10` clears all four. The solution now builds **0 warnings / 0 errors with the audit
enabled** (earlier verification on #362 had to pass `-p:NuGetAudit=false` to work around it).
Fixed by moving the pin, not by suppressing `NuGetAudit` — the audit was doing its job. The
comment now records that the correct response to NU1903 here is to bump, never to silence.

## Three things that changed shape in the port

**No merge-with-target preamble.** GitLab ran `git fetch` + `git merge` of the MR target in a
global `before_script` so a run tested "your changes + current target" rather than a stale
snapshot. Actions checks out the merge commit (`refs/pull/N/merge`) natively and blocks
conflicted PRs outright — so that preamble, and the `GIT_DEPTH` tuning that existed only to make
its merge-base lookup work, are both gone.

**No cross-job build artifact.** GitLab shipped `**/bin/` + `**/obj/` between stages. That
artifact couldn't carry the NuGet cache (it lives outside the checkout) — which *is* the root
cause of the issue-#21 false green documented in `test.yml` — and forced a `dotnet restore`
before every `--no-build` test anyway, plus hand-excluding ~100MB Playwright copies to stay under
the size limit. Each job now restores and builds in its own container, with `actions/cache`
sharing NuGet packages. The whole bug class goes away.

**No native JUnit widget.** Actions has no equivalent to GitLab's `reports: junit`. Counts go to
the job summary, raw XML uploads as an artifact. Deliberately not a third-party reporter action —
that's a supply-chain dependency on every CI run for cosmetics.

## Verification — every job, locally

| Check | Result |
|---|---|
| `actionlint` | clean |
| `format` | exit 0 |
| `license-scan` | exit 0, against the new `.github/licenses/` paths |
| `nginx-config-lint` | exit 0 — exact workflow command under Docker |
| `build` | 0 warnings / 0 errors, **audit enabled** |
| `unit-tests` | 501/501 |
| `eval-tests` | 51/51 |
| `evals` | PASS — 50 cases, 5 rubrics, all 100% |

The false-green guard was exercised against **all three** of its paths, not just the happy one:
no result files → exit 1; results reporting zero tests → exit 1; results carrying real failures →
exit 0 with counts surfaced (`dotnet test` owns reporting the red).

## Action required after merge

Status checks can't be marked required until they've run at least once. Once this merges, set
branch protection on `develop` and `main` per `CI-SETUP.md` §2 — **without it a red run is purely
advisory and the PR still merges.**

## Not done here

- `.gitlab-ci.yml` and `.gitlab/ci/` are left in place but **inert** — nothing on GitHub reads
  them. They're the reference for the CD port, particularly `deploy.yml`, whose comments encode
  real incidents (the `Llm__ApiKey` drift, the build-log-stream false positive, the scope-array
  truncation). Delete them once CD lands, not before.
- The license-gate JSONs are currently **duplicated** between `.gitlab/ci/` and
  `.github/licenses/` for that same reason.
- The `OPenEmrAgenda__ClientId` typo in `deploy.yml` (capital P, works only because .NET config
  binding is case-insensitive) is CD-side — worth fixing when those secrets are created fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


