### PR TITLE
docs: state the project's origin explicitly in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ no browser caller — is blocked at the proxy:
 | [`W2_ARCHITECTURE.md`](documentation/W2_ARCHITECTURE.md) | **(Week 2)** Multimodal Evidence Agent — document ingestion, the supervisor/worker graph, hybrid RAG, cloud redundancy, the eval gate, and the Week 2 decision log (W2-D1..D14) |
 | [`INTERFACE_CONTROL.md`](documentation/INTERFACE_CONTROL.md) | Interface Control Document (ICD) — the OpenEMR external interface (FHIR/OAuth/SMART) |
 | [`ENGINEERING_STANDARDS.md`](documentation/ENGINEERING_STANDARDS.md) | Stack, dependencies, coding/testing/security/logging standards |
-| [`supporting/`](documentation/supporting/) | Source requirement PDFs (Week 1 & 2) and the 5-minute architecture-defense decks (`Architecture_Defense.pptx`, `W2_Architecture_Defense.pptx`) |
+| [`supporting/`](documentation/supporting/) | The original Week 1 & 2 requirement briefs as issued (see [Origin](#origin)) and the 5-minute architecture-defense decks (`Architecture_Defense.pptx`, `W2_Architecture_Defense.pptx`) |
 
 ### Why so much cross-referencing
 
@@ -251,6 +251,19 @@ is encrypted at rest (`ENGINEERING_STANDARDS.md` §6, §11).
   source (`src/RestControllers/AuthorizationController.php`, `SMARTAuthorizationController.php`,
   `TokenIntrospectionRestController.php`, etc. — see `INTERFACE_CONTROL.md` A's "Confirmed in fork" note) than
   to guess from HTTP responses/logs alone.
+
+---
+
+## Origin
+
+This project began as a case study issued by **Gauntlet AI**. The original requirement briefs are preserved
+unaltered in [`documentation/supporting/`](documentation/supporting/) — `PRD.md`'s FR-/NFR- IDs trace back to
+them, so they are kept as source documents rather than edited.
+
+Everything else — the architecture, the sidecar design, the implementation, and the docs in
+[`documentation/`](documentation/) — is original work. The codebase was formerly namespaced
+`GauntletAI.AgentForge.*` and hosted on a Gauntlet-run GitLab; both have been retired in favour of
+`MarqSpec.AgentForge.*` on GitHub.
 
 ---
 


### PR DESCRIPTION
## Where the GauntletAI scrub actually stands

The prose scrub landed in #362 (`d14c9fa`). On `develop` today, **every tracked text file returns
zero matches** — README fork link repointed to GitHub, footer credit removed, INDEX §5 retitled,
PRD fork source reworded, and a dead GitLab issue link removed from `evidence.html` that had been
shipping in the running app's demo banner.

My earlier "fully scrubbed" claim was **narrower than it sounded**, and worth correcting: it used
`git grep -I`, which silently skips binary files. Re-running without that flag, plus unpacking
both `.pptx` archives entry-by-entry, gives the real picture:

| Location | Result |
|---|---|
| All tracked text files | 0 matches |
| `Architecture_Defense.pptx` (all archive entries) | 0 matches |
| `W2_Architecture_Defense.pptx` (all archive entries) | 0 matches |
| `Week_2_AgentForge.pdf` | 0 matches |
| **`Week_1_AgentForge.pdf`** | **1 — an embedded link to `Gauntlet-HQ/openemr-base-clean`** |

## What this PR changes

The scrub removed the footer credit and left the repo with **no provenance at all**, which
over-corrected in the other direction. The Week 1 & 2 briefs in `documentation/supporting/` are
the case study *as issued*, and `PRD.md`'s FR-/NFR- IDs trace back to them — that origin is
load-bearing context, not branding.

Adds a short **Origin** section that states plainly where the project came from, marks the briefs
as preserved-unaltered source documents, and draws the line between the issued case study and the
original work built on top of it. The `supporting/` index row now points at it.

## What this PR deliberately does not change

**The briefs themselves.** `Week_1_AgentForge.pdf` keeps its embedded link. Rewriting a document
authored by someone else to remove its origin would falsify the record of what was actually
issued — and it's the one artifact that evidences the provenance the Origin section now describes.

So one GauntletAI reference remains in the repo, by decision rather than by oversight, and it's
now documented as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
