### PR TITLE
docs: mask the demo admin password instead of publishing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ Reached through the same-origin reverse-proxy front door (`reverse-proxy/`, issu
 
 | Role | Username | Password |
 |---|---|---|
-| Administrator | `admin` | `P@ssw0rd1` |
-| Cardiologist (demo provider — the patients' attending) | `cardio1` | `P@ssw0rd1` |
+| Administrator | `admin` | **ask** |
+| Cardiologist (demo provider — the patients' attending) | `cardio1` | **ask** |
+
+> Both demo logins share one password, so it is withheld rather than printed — masking only the
+> administrator row would leave it readable on the row below. Ask the maintainer for it.
 
 ### Observability dashboard (Grafana)
 
@@ -58,14 +61,14 @@ logs are **operational only — no PHI** (see `NFR-SEC-W2-1`).
 
 | Service | Username | Password |
 |---|---|---|
-| Grafana (demo) | `admin` | `P@ssw0rd1` |
+| Grafana (demo) | `admin` | **ask** |
 
 > **Staging/demo only — not for production.** These are throwaway credentials for a synthetic-data, non-PHI
-> dashboard (same posture as the OpenEMR logins above), published here purely so a reviewer can open the demo.
-> A production deployment **must** replace them: set a strong, unique `GF_SECURITY_ADMIN_PASSWORD` (and rotate
-> `GF_SECURITY_ADMIN_USER`) on the `agentforge-grafana` service, keep the value out of source, and remove this
-> table. The real value lives in that Railway variable, not here. Prometheus and Loki stay reachable only over
-> the project's private network (`agentforge-prometheus.railway.internal:9090`,
+> dashboard (same posture as the OpenEMR logins above). The password is withheld rather than printed — ask the
+> maintainer. A production deployment **must** replace it anyway: set a strong, unique
+> `GF_SECURITY_ADMIN_PASSWORD` (and rotate `GF_SECURITY_ADMIN_USER`) on the `agentforge-grafana` service, and
+> keep the value out of source. The real value lives in that Railway variable, not here. Prometheus and Loki
+> stay reachable only over the project's private network (`agentforge-prometheus.railway.internal:9090`,
 > `agentforge-loki.railway.internal:3100`).
 
 ### Front-door surface (what's reachable, and how it's protected)

--- a/documentation/RAILWAY.md
+++ b/documentation/RAILWAY.md
@@ -336,8 +336,8 @@ Completed 2026-07-09 through 2026-07-11 against the fresh staging OpenEMR:
 > if there's a concrete reason to (see issue #44's closing note for the full
 > investigation trail).
 
-Admin login (demo): `admin` / `P@ssw0rd1` (also the `OE_PASS` service variable
-on `openemr`, kept in sync so a re-setup recreates the same credentials).
+Admin login (demo): `admin` / **ask** — the password is withheld from source; the live value is the
+`OE_PASS` service variable on `openemr`, kept in sync so a re-setup recreates the same credentials.
 
 ## Remaining setup (one-time)
 

--- a/tools/SeedDemoPatients/README.md
+++ b/tools/SeedDemoPatients/README.md
@@ -37,7 +37,8 @@ dotnet run --project tools/SeedDemoPatients
 Needs one interactive step: the script registers (or reuses, via `SeedDemo__ClientId`/
 `SeedDemo__ClientSecret`) a confidential OAuth client, prints its client_id, and pauses for you to
 enable it (Admin → System → API Clients) — freshly-registered clients land disabled. It then prints
-an authorize URL; open it, log in as `admin`/`P@ssw0rd1`, approve, and paste back the resulting
+an authorize URL; open it, log in as `admin` (password withheld from source — ask the maintainer, or
+read the `OE_PASS` service variable on `openemr`), approve, and paste back the resulting
 address-bar URL (the redirect target doesn't resolve — that's expected, the `code` is still in the
 URL). The access token this produces lives only in the process's memory — never logged, never
 written to disk.


### PR DESCRIPTION
Replaces the printed password with **ask** in the live-demo and Grafana credential tables.

## Scope: three files, not one

The same password string was published in three tracked files. Masking only the README would have
left it one `grep` away, so all three are masked:

| File | What was exposed |
|---|---|
| `README.md` | live-demo table (Administrator + Cardiologist) and the Grafana table |
| `documentation/RAILWAY.md` | admin login line |
| `tools/SeedDemoPatients/README.md` | inline in the OAuth walkthrough |

`git grep P@ssw0rd` now returns nothing.

## Why `cardio1` is masked too

Both OpenEMR demo logins share the same password. Masking only the Administrator row would have left
the identical value printed on the line directly below it — the mask would have been decorative. A
short note explains the omission so it doesn't read as an oversight.

## What is preserved

Where the real value lives is still documented — the `OE_PASS` service variable on `openemr`, and
`GF_SECURITY_ADMIN_PASSWORD` for Grafana — so this withholds the secret without breaking the
operational trail for whoever needs to actually log in.

## What this does NOT do

**It does not rotate the credential.** The password is still valid on the staging services, and it
remains recoverable from this repo's git history. Treat this as *withheld going forward*, not
revoked. If the goal is that nobody can use it, it needs rotating on the Railway services
(`OE_PASS`, `GF_SECURITY_ADMIN_PASSWORD`) — masking the docs alone won't achieve that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
