### PR TITLE
docs: footer says personal student project, not "internal project"

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,4 +267,4 @@ Everything else — the architecture, the sidecar design, the implementation, an
 
 ---
 
-*AgentForge Clinical Co-Pilot. Internal project; docs are living and versioned (`v0.1`).*
+*AgentForge Clinical Co-Pilot — a personal student project (see [Origin](#origin)); docs are living and versioned (`v0.1`).*


### PR DESCRIPTION
The README footer read `AgentForge Clinical Co-Pilot. Internal project; ...`. "Internal project" reads
as *company-internal*, which misrepresents what this is.

The [Origin](../blob/develop/README.md#origin) section already states it began as a Gauntlet AI case
study, so the footer now says **"a personal student project"** and links to Origin for the full
provenance.

```diff
-*AgentForge Clinical Co-Pilot. Internal project; docs are living and versioned (`v0.1`).*
+*AgentForge Clinical Co-Pilot — a personal student project (see [Origin](#origin)); docs are living and versioned (`v0.1`).*
```

One-line change. `git grep "internal project"` finds no other occurrence, and the `#origin` anchor
resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
