### PR TITLE
chore: ignore the gitlab-export archive (holds a live runners_token)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -497,3 +497,13 @@ secrets.json
 # tools/LoadTestChat's LoadTest__Debug=1 capture (screenshots/HTML dumps of live OpenEMR pages)
 debug-*.html
 debug-*.png
+
+# Local GitLab->GitHub migration archive. NEVER commit: the export's project.json
+# carries a live GitLab runners_token (gitleaks rule: gitlab-rrt), and the archive
+# also mirrors CI variables. It is read locally by the importer only, and must not
+# reach GitHub or any other remote. The agent-forge fork ignores this too.
+gitlab-export/
+
+# Claude Code local agent config - per-developer permission allowlists and
+# machine-specific paths, not shared project configuration.
+.claude/


### PR DESCRIPTION
Adds `gitlab-export/` and `.claude/` to `.gitignore`. **Security-relevant**: the migration
archive's `project.json` carries a live GitLab `runners_token` (gitleaks rule `gitlab-rrt`) and
mirrors CI variables, so it must never reach GitHub or any remote. It is read locally by the
importer only.

Split out of the docker-compose branch so the security fix lands on `develop` on its own, ahead of
the demo-stack review.

## Not a leak — a closed gap

Verified the folder was **never committed**: no object under `gitlab-export/` exists anywhere in
history, across every ref (checked earlier including the `rescue/*` branches). So this is preventive
— it closes a `git add -A`-away exposure that had not occurred. **No history rewrite or token
rotation needed on this account.** (The `runners_token` itself lives in the archive regardless; rotate
it whenever the GitLab project is formally retired, independent of this.)

Also ignores `.claude/` — per-developer permission allowlists and machine paths, likewise untracked
but committable.

## Verification

- cherry-picked clean onto `develop` (no conflict)
- `git check-ignore gitlab-export/` → matches; a full `git add -A` now stages only intended files
- read the pushed `.gitignore` back from the API — rules present at the expected lines

The `agent-forge` fork already ignores `gitlab-export/`; this brings the two repos in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
