### PR TITLE
ci: publish the sidecar image to GHCR on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,14 @@
 # -----------------------------------------------------------------------------
-# CI — lint, build, test, evals. Ported from the retired GitLab pipeline
+# CI — lint, build, test, evals, + publish the sidecar image to GHCR on release
+# (merge to main). Ported from the retired GitLab pipeline
 # (.gitlab/ci/{lint,build,test,evals}.yml); see documentation/CI-SETUP.md.
 #
-# This is the CI half only. The deploy/verify half (Railway deploys, post-deploy
-# smoke tests, integration tests) is a separate follow-up: it needs ~18 repository
-# secrets that do not exist yet, and it touches live infrastructure. Everything
-# here runs with NO secrets at all.
+# The lint/build/test/evals gates run with NO secrets. The `publish-image` job
+# (bottom of this file) builds the sidecar once and pushes it to GHCR using the
+# built-in GITHUB_TOKEN - still no repo secret. What is NOT here yet is the
+# Railway DEPLOY that consumes that image (re-assert vars + redeploy): it needs
+# RAILWAY_TOKEN_STAGING + the runtime-var secrets (not set yet) and a one-time
+# console reconfig of the service to image-source, so it lands as a follow-up.
 #
 # Three things changed shape in the port rather than being copied across:
 #
@@ -300,3 +303,111 @@ jobs:
           name: eval-results
           path: evals/results.json
           retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # PUBLISH-IMAGE — build the sidecar once and push it to GHCR, so Railway pulls
+  # a pre-built image instead of rebuilding from source on every `railway up`
+  # (ADR/RAILWAY.md). "Build once, deploy that exact artifact."
+  #
+  # ON MERGE TO main ONLY. In this repo main IS the release: develop is the sole
+  # integration branch, staging takes develop-only, main takes staging-only
+  # (human-promoted, single-source). So a push to main is the release event, and
+  # the published image == the deployed image == the released state. develop
+  # pushes and PRs run the gates above but do NOT publish.
+  #
+  # Gated on the full test matrix (needs: unit-tests, eval-tests, evals - build
+  # is their transitive dep), so a red suite never publishes a deployable image.
+  #
+  # Uses the built-in GITHUB_TOKEN (packages: write) - no secret to manage. The
+  # image carries NO secrets; runtime config comes from the Railway service's env
+  # at deploy time.
+  #
+  # NOTE: the Railway deploy that CONSUMES this image is a follow-up - it needs
+  # RAILWAY_TOKEN_STAGING (not yet set) and a one-time console reconfig of the
+  # service from build-from-source to this GHCR image. Publishing is independent
+  # and safe to land first.
+  #
+  # FIRST-PUBLISH console step: a new GHCR package is PRIVATE; flip it to public
+  # (Settings -> Packages -> agent-forge-copilot -> Change visibility) so Railway
+  # (and anyone) can pull without a credential.
+  # ---------------------------------------------------------------------------
+  publish-image:
+    name: publish-image
+    runs-on: ubuntu-latest
+    needs: [unit-tests, eval-tests, evals]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build to the local daemon first (single-platform; the deploy target is
+      # amd64), so the verify below runs against the exact image that will be
+      # pushed. The push step re-runs from the gha cache, so it is a cache hit,
+      # not a second full build.
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          push: false
+          tags: ${{ env.IMAGE }}:ci-candidate
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sanity-check the built image is the runnable sidecar before publishing -
+      # cheaper than discovering a broken publish at deploy time. Not a full boot
+      # (the app's ValidateOnStart needs OpenEmr/Llm config it must not carry), so
+      # this asserts the published entrypoint assembly is present in the runtime layer.
+      - name: Verify the image is the sidecar
+        run: |
+          set -euo pipefail
+          if docker run --rm --entrypoint sh "${IMAGE}:ci-candidate" -c "test -f /app/MarqSpec.AgentForge.Api.dll"; then
+            echo "OK: MarqSpec.AgentForge.Api.dll present in the runtime image."
+          else
+            echo "::error::Built image is missing the sidecar entrypoint assembly; refusing to publish."
+            exit 1
+          fi
+
+      - name: Compute tags
+        id: tags
+        run: echo "sha=sha-$(echo "${GITHUB_SHA}" | cut -c1-12)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:main
+            ${{ env.IMAGE }}:${{ steps.tags.outputs.sha }}
+          cache-from: type=gha
+
+      - name: Summary
+        run: |
+          {
+            echo "### Sidecar image published"
+            echo ""
+            echo '```'
+            echo "docker pull ${IMAGE}:${{ steps.tags.outputs.sha }}"
+            echo '```'
+            echo ""
+            echo "| Tag | |"
+            echo "|---|---|"
+            echo "| \`latest\` / \`main\` | move with main |"
+            echo "| \`${{ steps.tags.outputs.sha }}\` | immutable — pin the Railway deploy to this |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/documentation/CI-SETUP.md
+++ b/documentation/CI-SETUP.md
@@ -16,13 +16,16 @@ required.
 ```
 
 > **Migration status.** This repo ran on GitLab CI until the move to GitHub. The
-> **CI half** (lint, build, test, evals) is ported and live. The **CD half** —
-> Railway deploys, the post-deploy `/health` + `/ready` smoke tests, and the
-> health-gated integration suite — is **not yet ported**; it needs repository
-> secrets that do not exist yet and it touches live infrastructure. The retired
-> `.gitlab-ci.yml` and `.gitlab/ci/` are kept **temporarily and inertly** as the
-> reference for that port (nothing on GitHub reads them) and should be deleted
-> once CD lands. Until then, **deploys are manual**.
+> **CI half** (lint, build, test, evals) is ported and live, and the **sidecar
+> image is now published to GHCR** on merge to `main` (`publish-image`, below).
+> Still **not yet ported**: the Railway **deploy** that consumes that image
+> (re-assert vars + redeploy), the post-deploy `/health` + `/ready` smoke tests,
+> and the health-gated integration suite — they need repository secrets that do
+> not exist yet and touch live infrastructure. The retired `.gitlab-ci.yml` and
+> `.gitlab/ci/` are kept **temporarily and inertly** as the reference for that
+> port (nothing on GitHub reads them) and should be deleted once CD lands.
+> Until the deploy job lands, **deploys are manual** (and Railway still builds
+> from source until the service is repointed at the GHCR image — see `RAILWAY.md`).
 
 ## 1. What runs, and when
 
@@ -35,6 +38,7 @@ required.
 | `unit-tests` | test | fully mocked suite |
 | `eval-tests` | test | deterministic eval rubrics as xUnit theories |
 | `evals` | test | golden-set **hard gate** (Core Req 6) |
+| `publish-image` | publish | **main only**; builds the sidecar, verifies it, pushes to `ghcr.io/adammarquette/agent-forge-copilot` (`sha-<12>` + `main` + `latest`). Gated on `unit-tests`/`eval-tests`/`evals`. Uses the built-in `GITHUB_TOKEN` — no secret. |
 
 Triggers are `pull_request` (any branch) and `push` to **`main` and `develop`**.
 Concurrency cancels superseded runs on the same ref (the old `interruptible:

--- a/documentation/RAILWAY.md
+++ b/documentation/RAILWAY.md
@@ -17,7 +17,7 @@ never became available to diagnose it further — and was decommissioned
 
 | Service | Image / source | Notes |
 |---|---|---|
-| `agent-forge-api-staging` | this repo's root `Dockerfile` (.NET 10) | The BFF/API. Deployed by CI via `railway up`. Public domain → port 8080. |
+| `agent-forge-api-staging` | this repo's root `Dockerfile` (.NET 10) — **transitioning to the pre-built GHCR image** `ghcr.io/adammarquette/agent-forge-copilot` (see the image-source note below) | The BFF/API. Currently deployed by CI via `railway up` (build-from-source); the image is now published on merge to `main` by the `publish-image` CI job, and the service is being repointed to pull it. Public domain → port 8080. |
 | `openemr` | **built from the fork `adammarquette/agent-forge`** (`docker/railway/Dockerfile` via its own `railway.json`) — *not* the stock `openemr/openemr` image | OpenEMR EHR **with the `oe-module-agentforge` custom module baked in** (`COPY . /openemr`). Public domain → port 80. Deployed by the **fork's** CI on merge to the fork's `main`, not this repo's. |
 | `MySQL-gDNR` | `mysql:9.4` | OpenEMR's database. Private TCP only (port 3306). |
 
@@ -98,9 +98,22 @@ domain on port 80. Variables: `MYSQL_HOST/PORT/ROOT_PASS` (references to the MyS
 > Settings → Networking → set the domain's target port (80 for openemr, 8080
 > for agent-forge-api).
 
-**agent-forge-api-staging** — built from this repo's root `Dockerfile`
-(multi-stage .NET 10, binds Kestrel to Railway's `$PORT`). Public domain on
-port 8080. Deployed by CI via `railway up`, not by image.
+**agent-forge-api-staging** — multi-stage .NET 10, binds Kestrel to Railway's
+`$PORT`. Public domain on port 8080.
+
+> **Image source — moving from build-from-source to a pre-built GHCR image.**
+> CI's `publish-image` job (`.github/workflows/ci.yml`) now builds this repo's
+> root `Dockerfile` once on merge to `main` and pushes
+> `ghcr.io/adammarquette/agent-forge-copilot` (`sha-<12>` + `main` + `latest`),
+> the same build-once pattern as the OpenEMR fork. **Two operator steps complete
+> the switch:** (1) after the first publish, flip the GHCR package to **public**
+> (Settings → Packages → agent-forge-copilot → Change visibility); (2) reconfigure
+> the Railway service source from the repo Dockerfile to the GHCR image, pinned to
+> the immutable `sha-<12>` tag. Until (2), Railway keeps building from source via
+> `railway up` and the published image serves local `docker-compose` only. The CI
+> **deploy** job that re-asserts the vars below and redeploys the pulled image is a
+> follow-up (needs `RAILWAY_TOKEN_STAGING` + the runtime-var secrets).
+
 Variables (Options-pattern, `__` = section separator):
 
 > **Reverse-proxy front door (2026-07-13):** the SMART launch now routes through the


### PR DESCRIPTION
Builds the sidecar (`MarqSpec.AgentForge.Api`) **once** in CI and pushes it to
`ghcr.io/adammarquette/agent-forge-copilot`, so Railway can pull a pre-built, pinned artifact
instead of rebuilding from source on every `railway up`. Same build-once pattern as the OpenEMR fork
image.

## "Built from the release" — yes, and here that's `main`

`develop` is the sole integration branch; `staging` takes develop-only; `main` takes staging-only
(human-promoted, single-source). So a **push to `main` is the release event** — the published image
== the deployed image == the released state. `develop` pushes/PRs run the gates but **do not
publish**.

## The job

`publish-image`, appended to `ci.yml`:
- **main only** (`if: push && ref == refs/heads/main`)
- **gated on the full test matrix** (`needs: [unit-tests, eval-tests, evals]`) — a red suite never
  publishes a deployable image
- built-in `GITHUB_TOKEN` (`packages: write`) — **no repo secret**
- **verifies** the built image carries the entrypoint assembly before pushing — a broken build
  can't publish
- tags: `sha-<12>` (immutable, what the Railway deploy will pin), `main`, `latest`

## Scope: Phase 1 (publish) only

The Railway **deploy** that consumes this image — re-assert vars + redeploy — is a **follow-up**. You
chose *CI drives the deploy*, which needs `RAILWAY_TOKEN_STAGING` + the runtime-var secrets (not set
yet) and, because there's no `railway.json`, a **one-time console reconfig** of the service from
build-from-source to the GHCR image. Publishing is independent and safe to land first; until the
repoint, Railway keeps building from source and the image serves `docker-compose` only.

## Two operator steps (recorded in RAILWAY.md)

1. After the first publish (post-merge to main), flip the GHCR package **public** — new packages are
   private, so Railway/anyone can't pull until you do.
2. Reconfigure the Railway service source → the GHCR image, pinned to the `sha-<12>` tag.

## Verification

- sidecar Dockerfile **builds locally** (376 MB); the workflow's **exact verify command passes**
  against that real image
- `actionlint` clean
- read the pushed `ci.yml` back from the API — `publish-image` present as intended

Caveat (same as every workflow change here): `publish-image` first actually runs on the **post-merge
push to main**, not on this PR — GitHub uses the base branch's workflow for PR events, and it's
main-gated regardless.

## Docs in lockstep

`ci.yml` header, `CI-SETUP.md` (job table + migration note), `RAILWAY.md` (image-source transition +
the two operator steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
