### PR TITLE
feat(obs)+docs(w2): forward-port the cost/latency + audit-carryover work (reconciliation)

### DIFF
--- a/documentation/PERFORMANCE_BASELINES.md
+++ b/documentation/PERFORMANCE_BASELINES.md
@@ -117,3 +117,107 @@ baseline should be re-run once issue #41 is fully resolved to get the true stead
   measures per-turn cost/latency, not multi-turn conversation growth.
 - **Real spend.** As PRD.md anticipates, this run spent real money (~$6.99, see above) and made real calls
   against the real OpenEMR development instance.
+
+---
+
+# Week 2 — Multimodal Evidence flow (`POST /evidence/ask`)
+
+Week 2 cost/latency baseline for the multimodal-evidence graph (saga #71, epic E8 #86; FR-OBS-W2-3,
+NFR-PERF-W2). Traces to `W2_ARCHITECTURE.md` §6 and the Week 2 deliverables (cost + latency report, baselines
+vs Week 1).
+
+**Run date:** 2026-07-17. **Target:** the live `staging` deployment (`agent-forge-api-staging`, Railway
+project `lucid-clarity`), reached through the same-origin reverse-proxy front door under the `/agentforge`
+PathBase (`reverse-proxy/nginx.conf.template`, issue #62) — the sidecar's own public domain is retired, so
+`https://agent-forge-reverse-proxy-staging.up.railway.app/agentforge` is the only external entry. `/ready`
+was 200 (dependencies healthy) at run time. **Flow:** `POST /evidence/ask` — the stateless supervisor→worker
+graph (intake-extractor / evidence-retriever / answer-composer / critic), question-only (no document upload),
+so the hybrid-RAG guideline path runs but vision extraction does not. **Question:** a fixed guideline query
+(ACC/AHA LDL targets in high ASCVD risk). **Harness:** `tools/LoadTestChat` with `LoadTest__Question` set,
+which POSTs multipart `question` with a pooled real session cookie; 3 real sessions (Playwright `/launch`
+bootstrap) multiplexed across the concurrency. Nothing mocked — real LLM + retrieval + rerank spend.
+
+> **Why `/evidence/ask` and not a chat turn.** An earlier attempt drove the Week-1 chat hub (`AskFollowUp`).
+> It is **stateful** — it resumes per-session conversation state — so repeating one question returned cached
+> short replies (a contaminated p50 ~3.8s), and under concurrent multiplexing the pooled sessions would race
+> on shared conversation state. `/evidence/ask` is **stateless** (a fresh graph run per request), which both
+> fixes the contamination and is the canonical "Week 2 core flow" a grader runs (#86).
+
+## Results (client-side round-trip, NFR-PERF-4 shape)
+
+| Concurrency | Total calls | Errors | Error rate | p50 | p95 | p99 | Throughput |
+|---|---|---|---|---|---|---|---|
+| 10 | 54 | 0 | 0.00% | 10,704 ms | 14,938 ms | 15,202 ms | ~0.9 turns/s |
+| 50 | 356 | 0 | 0.00% | 7,523 ms | 12,862 ms | 20,206 ms | ~5.9 turns/s |
+
+**0% errors at both levels.** Throughput scales ~linearly (0.9 → 5.9 turns/s for 10 → 50 workers), consistent
+with an I/O-bound service with headroom (matches the Week 1 CPU/memory finding — not re-measured here). p50 is
+*lower* at 50 than at 10 because the concurrency-10 phase ran first, cold; the tail (p99) grows under load as
+expected.
+
+## Baseline vs Week 1
+
+Both are one full agent turn, client-timed, against real dependencies — Week 1 is a SignalR `RequestBrief`,
+Week 2 is an HTTP `POST /evidence/ask` (different transport, same "one turn" unit).
+
+| Metric | Week 1 brief | Week 2 evidence | Δ |
+|---|---|---|---|
+| p50 @ 10 | 16,210 ms | 10,704 ms | **−34%** |
+| p95 @ 10 | 20,765 ms | 14,938 ms | −28% |
+| p50 @ 50 | 17,876 ms | 7,523 ms | **−58%** |
+| p95 @ 50 | 25,795 ms | 12,862 ms | −50% |
+
+The evidence turn is **faster** than the pre-visit brief. Expected: the brief fans out several FHIR tool
+calls plus synthesis (~1.4 LLM round-trips/turn), while a question-only evidence turn is one guideline
+retrieval + one compose + a deterministic critic.
+
+## Bottleneck decomposition (per-worker, server-side)
+
+From `agentforge_worker_duration_seconds` and the retrieval/rerank histograms, delta over the run:
+
+| Stage | Avg per execution | Executions | Note |
+|---|---|---|---|
+| evidence-retriever (hybrid RAG) | **3.16 s** | 470 | dense+sparse+RRF; ~2.95 snippets/call; 100% hit rate |
+| answer-composer (LLM compose) | **4.51 s** | 411 | **dominant cost** — the single LLM call per turn |
+| critic (deterministic verify) | 0.16 ms | 411 | negligible — no LLM |
+| rerank (Cohere cross-encoder) | 141 ms | **20 / 470** | fired on only ~4% of retrievals — small corpus usually yields ≤ topK candidates, so rerank is skipped |
+
+Per completed turn the graph runs retriever → composer → critic sequentially (≈ 3.16 + 4.51 + ~0 ≈ 7.7 s),
+which accounts for essentially all of the client-observed p50; the rest is network + supervisor overhead.
+(Retriever executions, 470, exceed completed turns, 410, because in-flight requests at each 60 s cutoff
+completed retrieval but were cancelled before composing — they are not counted as client successes.)
+
+## Cost — **not obtainable from telemetry (instrumentation gap)**
+
+Across 410 completed turns and **411 answer-composer LLM calls**, `agentforge_llm_tokens_total` and
+`agentforge_llm_cost_usd_total` recorded a **zero delta**. The evidence graph's LLM usage is **not
+instrumented** for tokens/cost: `/evidence/ask` bypasses the `AgentOrchestrator` path where token/cost
+recording lives — the same evidence-path telemetry bypass `W2_AUDIT.md` flags for NFR-TRACE (per-encounter
+telemetry), now confirmed to extend to **cost**. So the "actual dollar figure" PRD.md asks for is **not
+measurable from metrics today** for this flow.
+
+Order-of-magnitude estimate only (pending instrumentation): the compose step sends the question + ~3
+guideline snippets (~1–3k input tokens) and returns a few hundred output tokens; at Claude Sonnet 5 rates
+($2/M in, $10/M out) that is roughly **$0.006–0.010 per turn**, i.e. **~$3** for this 410-turn run, plus
+negligible Cohere embed/rerank. Treat as an estimate, not a measurement.
+
+**Fixed in this change.** `EvidenceAgentSupervisor.ComposeAsync` now records the composer's usage via
+`IAgentForgeMetrics.RecordLlmUsage` (mirroring `AgentOrchestrator`), so `/evidence/ask` tokens and cost reach
+`agentforge_llm_tokens_total` / `_cost_usd_total`. The figures above are the **pre-instrumentation** run
+(metrics were blind to the evidence LLM call); the metered dollar figure replaces the estimate once this
+deploys to staging and a short pass is re-run. One smaller residual remains: the intake-extractor's
+`DocumentExtractor.CompleteAsync` — exercised only on document-upload turns, which this question-only run did
+not hit — is still unmetered.
+
+## Methodology notes
+
+- **Session pool, not per-connection login** (same constraint as Week 1): 3 real sessions bootstrapped via a
+  genuine `/launch` SMART login, multiplexed across the concurrency. For `/evidence/ask` the session is only
+  the auth anchor — the flow retrieves from the guideline corpus and makes no user-scoped FHIR call — so 3
+  sessions across 50 workers still exercises real server-side concurrency.
+- **Stateless flow**, so multiplexing many workers over few sessions is clean (no shared conversation state),
+  unlike the Week-1 hub.
+- **Real spend**, order ~\$3 (estimated — see the cost gap above). Question-only, so no vision-extraction cost;
+  a run with document upload (`file` + `docType`) would add the intake-extractor's multimodal call and cost.
+- **Not re-measured:** CPU/memory (Week 1 found the service I/O-bound with large headroom; nothing here
+  suggests otherwise) and a document-upload evidence turn.

--- a/documentation/W2_AUDIT.md
+++ b/documentation/W2_AUDIT.md
@@ -165,6 +165,17 @@ polish, most of it "Should"-tier:
     ([AgentOrchestratorLog.cs](../src/MarqSpec.AgentForge.Agent/AgentOrchestratorLog.cs)).
     <br>*Interpretation note:* the golden-set **eval is a CI-only offline gate**, so the per-encounter runtime
     analog of "eval outcome" is the verification/grounding gate — confirmed with the product owner.
+    <br>*Coverage caveats (added by the 2026-07-17 re-verification pass):* (a) the line is emitted **only on the
+    verified-final-answer path** ([AgentOrchestrator.cs:232-244](../src/MarqSpec.AgentForge.Agent/AgentOrchestrator.cs)) —
+    every deterministic-fallback exit (LLM failure, turn-deadline, tool-round-budget exceeded, still-malformed
+    output) returns via `BuildDeterministicFallback` **without** emitting it, so a **degraded/failed encounter
+    leaves no per-encounter record**. Against the FR-OBS-W2-1 "answerable for *any* past encounter" wording this
+    is a real edge: the encounters most worth inspecting (the failures) are exactly the ones not logged.
+    (b) the standalone Week-2 `/evidence/ask` supervisor graph does **not** emit this line — it bypasses
+    `AgentOrchestrator` (see NFR-TRACE-W2). Evidence retrieval **is** captured when the Week-1 agent drives
+    `retrieve_evidence` / `get_document_facts` as MCP tools (those turns get a line with `retrieval_hits` /
+    `extraction_confidence` populated), but the dedicated evidence endpoint is not — which bounds what the
+    cost/latency report (FR-OBS-W2-3) can measure from `encounter.telemetry` to the chat/brief/agenda flows.
 - **FR-OBS-W2-2 (W2 dashboard panels):** the Grafana dashboard carries the **"Week 2 — Multimodal Evidence
   Agent"** row (ingestion rate/latency, per-worker latency p95, routing decisions, evidence-retrieval hit rate
   + latency, rerank latency p50/p95, retrieval-degradations-by-stage) **plus a "Per-encounter story" Loki panel**
@@ -255,9 +266,49 @@ telemetry" — are resolved and dropped.)*
 
 ---
 
+## 5. Base-system findings carried forward (from AUDIT.md)
+
+> **Why this section exists.** [`AUDIT.md`](AUDIT.md) is the pre-agent baseline of the OpenEMR fork, preserved
+> as a historical snapshot and never edited. Its findings must not be lost as the weekly audits move on, so
+> **each weekly implementation audit carries the base findings forward with their current status** — the role
+> the retired `AUDIT_DELTA.md` used to play, now folded in here so there is one living audit rather than a
+> separate delta doc to keep in sync. Next week's audit inherits and updates this table.
+> **Legend:** ✅ Addressed · 🟡 Partial · ➖ Still open · 🔀 Superseded.
+
+| Base finding (AUDIT.md §) | Status | Where it stands now |
+|---|---|---|
+| §1/§2.1 Dev-compose weak creds + exposed side-channels | 🔀 Superseded | Railway staging behind a reverse proxy replaced the dev compose; sidecar on the private network, public domain removed. No longer the deployment path. |
+| §2.2 No per-patient authorization | ✅ Addressed | Sidecar is patient-scoped by construction — a session binds one `PatientSessionContext`, cross-patient asks refused (FR-CHAT-3). The agent inherits no blanket "read all patients" capability. |
+| §2.3 Injection | ➖ Unchanged | Base posture holds; the sidecar adds no SQL path into OpenEMR (FHIR/REST only). |
+| §2.4 `cookie_samesite` Strict→Lax for SMART launch | 🟡 Partial | Fork default is back to `Strict`, with `Lax`/`None` used per-context for the OAuth2/SMART session. *Open:* confirm agent-forge#26 formally closed (tracked as sidecar #63). |
+| §2.5 Crypto keys on the same volume as data | ➖ **Still open** | Production KMS/secret-store still needed; sidecar secrets are env/Options, no secrets in source. |
+| §3.1–3.3 Perf (no cache/replica/FT index; retrieval off the primary DB) | ✅ Followed | Retrieval + embeddings live in the sidecar's own Postgres (pgvector + HNSW), not OpenEMR's MySQL — exactly the §3.2 recommendation. Latency is LLM-dominated as predicted. |
+| §4.4 Separate OAuth2 FHIR client + custom module | ✅ Followed | Sidecar consumes SMART/OAuth FHIR under a scoped token; the UI ships as the `oe-module-agentforge` custom module. |
+| §5.1 Fragmented meds (two-table model) | 🟡 Partial | Agent reads FHIR `MedicationRequest`/`MedicationDispense`; the legacy `lists[type=medication]` source is not separately read. The schema fragmentation itself is unchanged. |
+| §5.2 Empty demo DB | ✅ Addressed | 7 synthetic cardiology patients seeded with problems/allergies/meds/encounters/labs (`seed_cardiology_demo.php`). *Not re-measured:* a fresh live staging row-count. |
+| §5.3 Failure modes (single-source meds, free-text-as-coded, null DOB, orphans) | 🟡 Mitigated | Source-attribution gate + critic/verifier target these; they remain verification problems by design, not eliminated. |
+| §6.1 Audit config-gated; base won't auto-log a service account's reads | ✅ Addressed | `AuditingMcpToolServer` + `AccessAuditLog` record clinician + patient + tool + correlation id on every tool call; the agent reads under the clinician's own SMART token, so OpenEMR's native audit attributes the reads too. |
+| §6.2 No automated retention/purge | ➖ **Still open** | HIPAA retention schedule undefined; out of the agent build's scope. |
+| §6.3 No breach detection/notification | ➖ **Still open** | The sidecar has an alerting surface, but no breach-notification workflow. |
+| §6.4 BAA / PHI-to-LLM disclosure discipline | ✅ Addressed (architecture) | Correlation id per call; no PHI in general logs (CI `no_phi_in_logs`); minimum-necessary field selection; access-audit stream kept distinct; TLS in transit; demo-data-only holds. |
+
+**Still open from the base system (unchanged, carried forward):** crypto keys on the same volume (§2.5),
+automated audit retention/purge (§6.2), breach detection/notification (§6.3), schema-level data fragmentation
+(§5.1), and base safety toggles remaining opt-out (§2.1/§6.1). These are base-EHR policy/infra gaps the agent
+build never claimed to fix; the agent's own always-on audit choke point backstops, but does not replace, the
+base toggles.
+
+---
+
 *Re-audit reflects `develop` as of 2026-07-17 (supersedes 2026-07-16, which superseded 2026-07-15). Status is
 from code inspection, plus **live verification on staging** for FR-CITE-2 (which is how three defects behind a
-code-inspection ✅ were found — see §2.4). "Not fully traced" items need a short confirmation pass. Related:
+code-inspection ✅ were found — see §2.4). **Independently re-verified 2026-07-17 (post-early-submission):**
+FR-RAG (all four stages — dense pgvector(1536)+HNSW, sparse FTS, RRF, Cohere rerank — live and DI-wired from
+both `/evidence/ask` and the chat `retrieve_evidence` tool, not orphaned), FR-OBS-W2-1 (seven-signal line
+confirmed; two coverage caveats added to §2.6), NFR-TRACE (no graph spans; tracer console-only — the one OTLP
+exporter belongs to the logs→Loki pipeline, not traces), and the NFR-API/HEALTH/SEC "declared-but-thin" gaps
+all confirmed against code — **no finding changed**. "Not fully traced" items need a short confirmation pass.
+Related:
 saga #71. Closed since the 2026-07-16 pass — #135 (FR-OBS-W2-1 per-encounter telemetry), #128 (Binary scope +
 reproducible client registration), #130/#136 (click-to-source boxes), #131/#132 (citation UX + prompt), #126
 (brief latency), #127 (CI deploy false-fail). Earlier: #82 (FR-RAG), #96/#109 (FR-CITE-2), #85/#57 + W2 metrics

--- a/src/MarqSpec.AgentForge.Agents/EvidenceAgentSupervisor.cs
+++ b/src/MarqSpec.AgentForge.Agents/EvidenceAgentSupervisor.cs
@@ -165,6 +165,10 @@ public sealed class EvidenceAgentSupervisor : IEvidenceAgentSupervisor
             new LlmRequest(EvidenceComposerPrompt.System, [LlmMessage.FromText(LlmRole.User, userContent)]),
             cancellationToken);
 
+        // Meter the composer's LLM call, the same way the Week-1 orchestrator does - the evidence graph
+        // bypasses AgentOrchestrator, so without this the Week 2 flow's tokens/cost never reach the metrics.
+        _metrics.RecordLlmUsage(response.Usage.InputTokens, response.Usage.OutputTokens, response.Usage.EstimatedCostUsd);
+
         return response.Content;
     }
 

--- a/tests/MarqSpec.AgentForge.UnitTests/Agents/EvidenceAgentSupervisorTests.cs
+++ b/tests/MarqSpec.AgentForge.UnitTests/Agents/EvidenceAgentSupervisorTests.cs
@@ -224,4 +224,21 @@ public sealed class EvidenceAgentSupervisorTests
         // The stubbed retriever returns no snippets, so this turn is a retrieval miss (hit: false, 0 results).
         A.CallTo(() => _metrics.RecordEvidenceRetrieval(false, 0, A<TimeSpan>._)).MustHaveHappenedOnceExactly();
     }
+
+    [Fact]
+    public async Task RunAsync_RecordsComposerLlmUsage()
+    {
+        // Guards the Week 2 cost signal: the answer-composer's LLM call must be metered into
+        // agentforge_llm_tokens_total / _cost_usd_total, else the evidence flow's token/cost is invisible -
+        // /evidence/ask bypasses AgentOrchestrator, which is where the Week-1 path records it.
+        // reference: documentation/PERFORMANCE_BASELINES.md (Week 2 cost gap)
+        var sut = CreateSut();
+        A.CallTo(() => _llm.CompleteAsync(A<LlmRequest>._, A<CancellationToken>._))
+            .Returns(new LlmResponse("draft answer", [], LlmStopReason.EndTurn, new LlmUsage(137, 24, 0.0042m)));
+        var request = new EvidenceAgentRequest { PatientId = "p1", Question = "What do the guidelines say?" };
+
+        await sut.RunAsync(request, CancellationToken.None);
+
+        A.CallTo(() => _metrics.RecordLlmUsage(137, 24, 0.0042m)).MustHaveHappenedOnceExactly();
+    }
 }

--- a/tools/LoadTestChat/LoadTestRunner.cs
+++ b/tools/LoadTestChat/LoadTestRunner.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.SignalR.Client;
 
 namespace MarqSpec.AgentForge.LoadTestChat;
 
-/// <summary>Outcome of a single real chat-turn call (<c>RequestBrief</c>).</summary>
+/// <summary>Outcome of a single real turn call (<c>RequestBrief</c> or <c>POST /evidence/ask</c>).</summary>
 public sealed record CallResult(bool Success, double LatencyMs, string? Error);
 
 /// <summary>Aggregated results for one concurrency level - Epic 12's NFR-PERF-4 deliverable shape.</summary>
@@ -44,30 +44,48 @@ public sealed record LoadTestResult(int Concurrency, TimeSpan Duration, IReadOnl
 }
 
 /// <summary>
-/// Drives concurrent, real SignalR chat turns (<c>ChatHub.RequestBrief</c>) against a real deployed
-/// AgentForge instance, multiplexing a small pool of real session cookies (obtained via a genuine
-/// browser <c>/launch</c> login - see README.md) across many concurrent connections. This is Epic
-/// 12's load-test harness (PRD.md NFR-PERF-3/4): every call is a real chat turn against real
-/// OpenEMR/LLM dependencies, nothing here is mocked or synthetic.
+/// Drives concurrent, real turns against a deployed AgentForge instance, multiplexing a small pool of real
+/// session cookies (genuine browser <c>/launch</c> logins - see README.md) across many concurrent workers.
+/// Two flows: the Week-1 pre-visit brief over SignalR (<c>ChatHub.RequestBrief</c>), and - when a question is
+/// supplied - the stateless Week-2 evidence graph over HTTP (<c>POST /evidence/ask</c>). Every call is a real
+/// turn against real OpenEMR/LLM/retrieval dependencies (PRD.md NFR-PERF-3/4); nothing here is mocked.
 /// </summary>
 public static class LoadTestRunner
 {
     public static async Task<LoadTestResult> RunAsync(
-        string baseUrl, IReadOnlyList<string> sessionCookies, int concurrency, TimeSpan duration)
+        string baseUrl, IReadOnlyList<string> sessionCookies, int concurrency, TimeSpan duration,
+        string? question = null)
     {
         var results = new ConcurrentBag<CallResult>();
         using var cts = new CancellationTokenSource(duration);
 
-        var workers = Enumerable.Range(0, concurrency)
-            .Select(i => RunWorkerAsync(baseUrl, sessionCookies[i % sessionCookies.Count], results, cts.Token))
-            .ToArray();
-
-        await Task.WhenAll(workers).ConfigureAwait(false);
+        if (question is null)
+        {
+            var workers = Enumerable.Range(0, concurrency)
+                .Select(i => RunBriefWorkerAsync(baseUrl, sessionCookies[i % sessionCookies.Count], results, cts.Token))
+                .ToArray();
+            await Task.WhenAll(workers).ConfigureAwait(false);
+        }
+        else
+        {
+            // /evidence/ask is stateless (a fresh supervisor-graph run per request, no conversation store), so
+            // many concurrent workers can safely share the small cookie pool - each request stands alone, unlike
+            // the stateful chat hub. UseCookies=false + a per-request Cookie header lets one HttpClient serve
+            // every pooled session without a shared container mixing them.
+            var askUri = $"{baseUrl.TrimEnd('/')}/evidence/ask";
+            using var handler = new HttpClientHandler { UseCookies = false };
+            using var http = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(180) };
+            var workers = Enumerable.Range(0, concurrency)
+                .Select(i => RunEvidenceWorkerAsync(
+                    http, askUri, sessionCookies[i % sessionCookies.Count], question, results, cts.Token))
+                .ToArray();
+            await Task.WhenAll(workers).ConfigureAwait(false);
+        }
 
         return new LoadTestResult(concurrency, duration, [.. results]);
     }
 
-    private static async Task RunWorkerAsync(
+    private static async Task RunBriefWorkerAsync(
         string baseUrl, string cookie, ConcurrentBag<CallResult> results, CancellationToken cancellationToken)
     {
         var hubUri = new Uri($"{baseUrl.TrimEnd('/')}/hubs/chat");
@@ -107,6 +125,39 @@ public static class LoadTestRunner
             {
                 // TaskCanceledException derives from OperationCanceledException - this fires when the
                 // duration elapses mid-call. That's the runner's normal stop signal, not a failed call.
+                break;
+            }
+            catch (Exception ex)
+            {
+                results.Add(new CallResult(false, stopwatch.Elapsed.TotalMilliseconds, ex.Message));
+            }
+        }
+    }
+
+    private static async Task RunEvidenceWorkerAsync(
+        HttpClient http, string askUri, string cookie, string question,
+        ConcurrentBag<CallResult> results, CancellationToken cancellationToken)
+    {
+        var stopwatch = new Stopwatch();
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            stopwatch.Restart();
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, askUri);
+                request.Headers.Add("Cookie", cookie); // the pooled cookie is already a raw "Name=Value" header
+                request.Content = new MultipartFormDataContent { { new StringContent(question), "question" } };
+
+                using var response = await http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
+                // Drain the body so the measured time covers the whole graph run, not just the response headers.
+                _ = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                results.Add(new CallResult(true, stopwatch.Elapsed.TotalMilliseconds, null));
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Our own duration token fired - the runner's normal stop, not a failed call. (An HttpClient
+                // per-request timeout throws with the token NOT cancelled, so it falls through to be recorded.)
                 break;
             }
             catch (Exception ex)

--- a/tools/LoadTestChat/Program.cs
+++ b/tools/LoadTestChat/Program.cs
@@ -1,14 +1,20 @@
 using System.Globalization;
 using MarqSpec.AgentForge.LoadTestChat;
 
+// The sidecar's own public domain was retired; it is reached only through the same-origin reverse-proxy
+// front door under the /agentforge PathBase (reverse-proxy/nginx.conf.template). reference: gitlab#62
 var baseUrl = Environment.GetEnvironmentVariable("LoadTest__BaseUrl")
-    ?? "https://agent-forge-api-staging-staging.up.railway.app";
+    ?? "https://agent-forge-reverse-proxy-staging.up.railway.app/agentforge";
 var durationSeconds = int.Parse(
     Environment.GetEnvironmentVariable("LoadTest__DurationSeconds") ?? "15", CultureInfo.InvariantCulture);
 var concurrencyLevels = (Environment.GetEnvironmentVariable("LoadTest__ConcurrencyLevels") ?? "10")
     .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
     .Select(s => int.Parse(s, CultureInfo.InvariantCulture))
     .ToArray();
+
+// Null/unset => Week-1 RequestBrief baseline (unchanged). Set => Week-2 evidence turn via AskFollowUp, so the
+// one harness produces the vs-Week-1 comparison the cost/latency report needs. reference: gitlab#86
+var question = Environment.GetEnvironmentVariable("LoadTest__Question");
 
 string[] sessionCookies;
 var cookiesRaw = Environment.GetEnvironmentVariable("LoadTest__SessionCookies");
@@ -24,7 +30,10 @@ else
     var loginPassword = Environment.GetEnvironmentVariable("LoadTest__LoginPassword")
         ?? throw new InvalidOperationException("LoadTest__LoginPassword is required alongside LoadTest__LoginUsername.");
     var patientIds = (Environment.GetEnvironmentVariable("LoadTest__PatientIds")
-            ?? "a2362388-35e0-43de-97dc-450bd53e624e,a2382918-ebb2-46df-ba28-09dee162c67c,a2382cf3-3190-4ec5-94c8-4b507d4d08be")
+            // Current seeded cohort (the earlier ids were retired by a reseed); scrape the /smart/patient-select
+            // page with LoadTest__Debug=1 if these ever stop matching. For /evidence/ask the patient is only the
+            // session's auth anchor - the flow retrieves from the guideline corpus, not the patient's FHIR record.
+            ?? "a23a7ed4-54de-4dc7-b5c4-93d3e1d03fd4,a23a7ed5-867e-4ab3-bd7d-25fcc5b24f66,a23a7ed6-a13f-4241-a626-86a1589f5be8")
         .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
     Console.WriteLine($"No LoadTest__SessionCookies set - bootstrapping {patientIds.Length} real session(s) via Playwright...");
@@ -39,13 +48,22 @@ else
     sessionCookies = [.. bootstrapped];
 }
 
+var flowUnderTest = question is null
+    ? "RequestBrief (Week-1 pre-visit brief, SignalR)"
+    : "POST /evidence/ask (Week-2 evidence graph, hybrid RAG)";
 Console.WriteLine($"Load-testing {baseUrl}/hubs/chat with {sessionCookies.Length} pooled session(s), {durationSeconds}s per concurrency level.");
+Console.WriteLine($"Flow under test: {flowUnderTest}.");
+if (question is not null)
+{
+    Console.WriteLine($"Evidence question: \"{question}\"");
+}
 Console.WriteLine("Every call is a real chat turn against real OpenEMR/LLM dependencies - this spends real money.");
 
 foreach (var concurrency in concurrencyLevels)
 {
     Console.WriteLine();
     Console.WriteLine($"=== Concurrency {concurrency} ===");
-    var result = await LoadTestRunner.RunAsync(baseUrl, sessionCookies, concurrency, TimeSpan.FromSeconds(durationSeconds));
+    var result = await LoadTestRunner.RunAsync(
+        baseUrl, sessionCookies, concurrency, TimeSpan.FromSeconds(durationSeconds), question);
     result.Print();
 }

--- a/tools/LoadTestChat/README.md
+++ b/tools/LoadTestChat/README.md
@@ -39,14 +39,31 @@ money** (PRD.md explicitly expects and asks for the actual dollar figure to be r
 `agentforge_llm_cost_usd_total` metric). Start with a short, low-concurrency dry run to confirm the harness
 actually works before running the full 10/50-concurrent-user pass.
 
+### Measuring the Week-2 evidence flow
+
+Set `LoadTest__Question` to a guideline/evidence question and every call becomes an `AskFollowUp` turn that
+drives the hybrid-RAG `retrieve_evidence` path (Core Req 3) instead of the Week-1 brief. Both flows share the
+same client-side round-trip measurement, so the two runs are directly comparable — the vs-Week-1 baseline the
+cost/latency report needs. reference: gitlab#86
+
+```bash
+LoadTest__LoginUsername=cardio1 LoadTest__LoginPassword='<demo password>' \
+LoadTest__Question="What do the current cardiology guidelines recommend for this patient's LDL target given their ASCVD risk?" \
+LoadTest__ConcurrencyLevels="10,50" LoadTest__DurationSeconds="60" \
+dotnet run --project tools/LoadTestChat
+```
+
 ### Environment variables
 
 | Variable | Purpose |
 |---|---|
-| `LoadTest__SessionCookies` | **Required.** `;`-separated `Name=Value` session cookies from real browser logins |
+| `LoadTest__SessionCookies` | **Required unless the login vars below are set.** `;`-separated `Name=Value` session cookies from real browser logins |
 | `LoadTest__BaseUrl` | Deployed base URL (defaults to the staging Railway instance) |
 | `LoadTest__ConcurrencyLevels` | `,`-separated concurrency levels to run in sequence (default `10`) |
 | `LoadTest__DurationSeconds` | How long to hammer each concurrency level, in seconds (default `15`) |
+| `LoadTest__Question` | If set, every call is an `AskFollowUp(question)` **evidence turn** (Week-2 hybrid-RAG path, Core Req 3) instead of a `RequestBrief` brief (Week-1). Use a guideline/evidence question so the agent invokes `retrieve_evidence`. |
+| `LoadTest__LoginUsername` / `LoadTest__LoginPassword` | Alternative to `LoadTest__SessionCookies`: auto-bootstrap real sessions via Playwright (a genuine `/launch` SMART login). |
+| `LoadTest__PatientIds` | `,`-separated patient ids for the Playwright bootstrap - one distinct session per id. |
 
 ## Output
 

--- a/tools/LoadTestChat/SessionBootstrap.cs
+++ b/tools/LoadTestChat/SessionBootstrap.cs
@@ -39,6 +39,12 @@ public static class SessionBootstrap
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = 15000 })
             .ConfigureAwait(false);
 
+        if (Environment.GetEnvironmentVariable("LoadTest__Debug") == "1")
+        {
+            Console.WriteLine($"[debug] after login submit, landed on: {page.Url}");
+            await File.WriteAllTextAsync("debug-after-login.html", await page.ContentAsync(), cancellationToken).ConfigureAwait(false);
+        }
+
         var patientButtonSelector = $"button[data-patient-id='{patientId}']";
         var patientButton = await page.WaitForSelectorAsync(patientButtonSelector, new PageWaitForSelectorOptions { Timeout = 15000 })
             .ConfigureAwait(false)


### PR DESCRIPTION
Closes the last open thread from the migration: forward-ports the **only** unmerged branch with
unique engineering value (`perf/w2-cost-latency-report`) onto `develop`. That branch already
contained `docs/w2-audit-carryover`'s commit via a GitLab-era merge, so **one port covers both**
reconcile branches.

## What lands — each verified absent on `develop` first

- **Evidence-graph LLM metering** (`EvidenceAgentSupervisor` → `RecordLlmUsage`): the evidence graph
  bypasses `AgentOrchestrator`, so without this the **Week-2 flow's tokens/cost never reached the
  metrics** — a live observability hole, now closed, with a new unit test
  (`RunAsync_RecordsComposerLlmUsage`).
- **`PERFORMANCE_BASELINES.md`** gains the Week-2 evidence-flow cost/latency baselines (119 → **223
  lines**; `develop` had *zero* Week-2 content) — closes the `NFR-PERF-W2 ❌ Gap` the W2 audit flags.
- **`W2_AUDIT.md` §5** "Base-system findings carried forward" + the 2026-07-17 coverage-caveats
  re-verification (absent on `develop`).
- **LoadTestChat** harness support for the cost/latency runs.

## Method (same as #370)

Same-path files 3-way merged from the branch's fork point (`ceb8f2d`); the two renamed `src`/`tests`
files applied as **namespace-normalized patches** (branch content predates the rename); namespace
scrub as the safety net. **Zero conflicts.**

## Verification

- build **0 warnings / 0 errors** under warnings-as-errors
- **502/502** unit tests pass in the Linux SDK container — was 501; the +1 is the ported metering test
  *(the local Windows run shows spurious `0x800711C7` Smart-App-Control DLL-block failures — a known
  environment gotcha, not real)*
- **no conflict markers, no `GauntletAI`** in any changed file

## After this merges

The four obsolete unmerged branches (`cicd-init`, `ci/dev-environment`, `demo/eval-regression`,
`feat/integration-tests-post-deploy-70`) get deleted, along with `perf/w2-cost-latency-report` and
`docs/w2-audit-carryover` now that their content has landed. That empties the reconciliation column:
the repo drops to the 3 ladder branches + 3 `rescue/*`, every branch accounted for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
