### PR TITLE
docs(demo): zero-config default local credential for the compose stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,13 @@
 # Copy to `.env` and edit. `.env` is gitignored - never commit real values.
 #   cp .env.example .env
 
-# --- Required for the default tier (OpenEMR only) ----------------------------
+# --- Optional for the default tier (OpenEMR only) ----------------------------
 
-# OpenEMR admin password, set at first boot. Pick your own; there is no default,
-# so compose fails fast rather than standing up a demo on a known password.
-OPENEMR_ADMIN_PASSWORD=
+# OpenEMR admin password, set at first boot. Defaults to `LocalDev1!` if unset
+# (see docker-compose.yml) so `docker compose up` works with zero config. This is
+# a throwaway local default, deliberately NOT the staging password. Set it here
+# only if you want a different one, or before exposing the stack beyond localhost.
+# OPENEMR_ADMIN_PASSWORD=LocalDev1!
 
 # Host port for the front door. Everything is reached through this one origin.
 DEMO_PORT=8080

--- a/README.md
+++ b/README.md
@@ -40,12 +40,27 @@ Two ways to see this working: the hosted demo below, or your own stack via
 [`docker-compose.yml`](docker-compose.yml).
 
 ```bash
-cp .env.example .env          # set OPENEMR_ADMIN_PASSWORD
 docker compose up -d          # OpenEMR + the AgentForge module + the front door
 ```
 
-Then open **<http://localhost:8080>** and log in as `admin`. That tier needs **no API key** — you get
-OpenEMR with the module installed, including the AgentForge launch button and the Daily Agenda tab.
+Then open **<http://localhost:8080>** and log in with the **default local credentials**:
+
+| Username | Password |
+|---|---|
+| `admin` | `LocalDev1!` |
+
+Zero config — that tier needs **no API key** and **no `.env`**; you get OpenEMR with the module
+installed (the AgentForge launch button + the Daily Agenda tab). `LocalDev1!` is a throwaway default
+baked into `docker-compose.yml`; it is **not** the hosted-demo password (which stays withheld), and
+it's safe to publish because this stack is ephemeral, localhost-only, and synthetic-data. Override it
+by setting `OPENEMR_ADMIN_PASSWORD` in a `.env` (`cp .env.example .env`) before exposing the stack
+beyond your machine.
+
+> **`admin` is the only login a fresh stack creates.** The `cardio1` demo cardiologist and the demo
+> patients are **not** built in — they need a seed step (create the provider in Admin → Users, run
+> `tools/SeedDemoPatients`). Automating that into the compose bring-up is tracked in
+> [#375](https://github.com/adammarquette/agent-forge-copilot/issues/375); until then, a fresh stack
+> is a bare OpenEMR + the module.
 
 The OpenEMR image is pulled from `ghcr.io/adammarquette/agent-forge`, published by the
 [fork's](https://github.com/adammarquette/agent-forge) own pipeline. The compose file pins an

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,13 @@ services:
       MYSQL_PASS: ${MYSQL_PASSWORD:-openemr}
       MYSQL_DATABASE: openemr
       OE_USER: admin
-      OE_PASS: ${OPENEMR_ADMIN_PASSWORD:?set OPENEMR_ADMIN_PASSWORD in .env}
+      # Zero-config LOCAL default so `docker compose up` just works. Deliberately
+      # NOT the staging admin password (which is withheld from source) - this stack
+      # is ephemeral, localhost-only, synthetic data, so a known throwaway default
+      # is fine and can't reach anything shared. Override in .env for a non-throwaway
+      # stack. `admin` is the only login a fresh boot creates; `cardio1` + demo
+      # patients need the seed/bootstrap (gh#375), not built-in.
+      OE_PASS: ${OPENEMR_ADMIN_PASSWORD:-LocalDev1!}
       # Named volumes mount EMPTY - they do not inherit image contents. The
       # OpenEMR image only restores its sites/ skeleton from /swarm-pieces (and
       # runs first-boot setup) when SWARM_MODE=yes and the replica elects itself


### PR DESCRIPTION
Makes `docker compose up` work with **no `.env`** and documents the default local login — but does it
honestly, which turned up two things worth surfacing.

## What changed

- `OPENEMR_ADMIN_PASSWORD` now **defaults** to `LocalDev1!` (was a required `:?` that failed fast).
  Zero config: `docker compose up -d` → log in as `admin` / `LocalDev1!`.
- README "Run it locally" documents that credential in a table.

## Two deliberate calls (decided with you)

**Distinct local password, not `P@ssw0rd1`.** You asked for `P@ssw0rd1`, but that's the *live staging
admin password* we masked earlier — publishing it in the README re-exposes the string that unlocks
the reachable `…-staging.up.railway.app` deployment. So the local default is a distinct throwaway
(`LocalDev1!`), and staging stays masked. Verified `P@ssw0rd1` is **not** reintroduced anywhere. (It's
safe to publish `LocalDev1!` — ephemeral, localhost-only, synthetic data.)

**`admin` only — `cardio1` isn't real yet.** A fresh compose stack creates **only** `admin`. `cardio1`
is a manual `Admin → Users` step the seed *assumes*, and demo patients need `tools/SeedDemoPatients`
(also manual) — the compose runs neither. Documenting `cardio1/<pw>` as a working login would've been
false, so the README says so plainly and points the seed/bootstrap automation at
[#375](https://github.com/adammarquette/agent-forge-copilot/issues/375).

## Verification

`docker compose config` valid with **no `.env`**, resolving `OE_PASS: LocalDev1!`; **no `P@ssw0rd1`**
in any tracked file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
