### PR TITLE
docs(railway): refresh sidecar image pin to sha-60c9495d39ff

### DIFF
--- a/documentation/RAILWAY.md
+++ b/documentation/RAILWAY.md
@@ -111,8 +111,11 @@ domain on port 80. Variables: `MYSQL_HOST/PORT/ROOT_PASS` (references to the MyS
 > `Dockerfile` once on merge to `main` and pushes
 > `ghcr.io/adammarquette/agent-forge-copilot` (`sha-<12>` + `main` + `latest`),
 > the same build-once pattern as the OpenEMR fork. The Railway service source is
-> now that image, **pinned to `sha-f3203a6d5f38`** (the package is public, so no
-> pull credential). This replaced build-from-source, which had silently frozen:
+> now that image, pinned to a specific `sha-<12>` — currently
+> **`sha-60c9495d39ff`** (the promoted-`main` build; this value moves on each
+> roll-forward, so treat the live service source as truth, not this line) (the
+> package is public, so no pull credential). This replaced build-from-source, which
+> had silently frozen:
 > Railway kept rebuilding a months-old `railway up` snapshot that still pinned the
 > vulnerable `System.Security.Cryptography.Xml 10.0.9`, so every redeploy failed
 > `dotnet restore` on NU1903 and the last good deploy was weeks stale — pulling the


### PR DESCRIPTION
## What

One-line freshness fix to `documentation/RAILWAY.md`: the `agent-forge-api-staging` sidecar's live Railway source was rolled forward from `sha-f3203a6d5f38` → **`sha-60c9495d39ff`** (the promoted-`main` build), so the doc's hard-coded pin was stale.

Also reworded the note so it **tracks "the current promoted-`main` sha"** and tells readers to treat the live service source as truth — a specific sha rots on every roll-forward, so the doc shouldn't pretend to be authoritative for it.

## Why now

Operational roll-forward performed this session after `develop → staging → main` promotion (#380/#381):
- `serviceInstanceUpdate` `source.image` → new tag, then `serviceInstanceDeploy` → **deploy SUCCESS** (old deployment REMOVED).
- Verified live on the new image: `/agentforge/health` **200**, `/` **302** (OpenEMR), `/agentforge/launch` **302 → on-origin OpenEMR authorize** with correct `redirect_uri=…/agentforge/callback` + `aud=…/apis/default/fhir`.

Docs-in-lockstep: the bump isn't "done" until RAILWAY.md reflects it.

## Scope

Doc-only, single paragraph. No code, no behavior change.

Related to #379 (the CD **deploy** job will automate this pin-bump + var re-assert; this just keeps the manual-process doc accurate until then).

Assisted-by: Claude Opus 4.8